### PR TITLE
Fix line folding

### DIFF
--- a/calendar_test.go
+++ b/calendar_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestCalendarStream(t *testing.T) {
@@ -197,5 +198,17 @@ END:VCALENDAR
 		//t.Logf("\n\n\n%s \nvs\n \n\n\n%s \nvs \n\n%s\n\n", string(structurejson), input, output)
 		t.Logf("Input:\n\n%s \nvs\n \nOutput\n\n%s", input, output)
 		t.Fail()
+	}
+}
+
+func TestLineFolding(t *testing.T) {
+	c := NewCalendar()
+	// Repeating a string that contains long runes (size > 1 byte)
+	// 75 time to be sure that line folding is needed.
+	const runesToOverflowLine = 75
+	c.SetDescription(strings.Repeat("世界", runesToOverflowLine))
+	text := c.Serialize()
+	if !utf8.ValidString(text) {
+		t.Fatalf("Serialized .ics calendar isn't valid UTF-8 string")
 	}
 }

--- a/property.go
+++ b/property.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 type BaseProperty struct {
@@ -43,6 +44,18 @@ func WithRSVP(b bool) PropertyParameter {
 	}
 }
 
+func trimUT8StringUpTo(maxLength int, s string) string {
+	length := 0
+	for _, r := range s {
+		newLength := length + utf8.RuneLen(r)
+		if newLength > maxLength {
+			break
+		}
+		length = newLength
+	}
+	return s[:length]
+}
+
 func (property *BaseProperty) serialize(w io.Writer) {
 	b := bytes.NewBufferString("")
 	fmt.Fprint(b, property.IANAToken)
@@ -65,13 +78,15 @@ func (property *BaseProperty) serialize(w io.Writer) {
 	fmt.Fprint(b, property.Value)
 	r := b.String()
 	if len(r) > 75 {
-		fmt.Fprint(w, r[:75], "\r\n")
-		r = r[75:]
+		l := trimUT8StringUpTo(75, r)
+		fmt.Fprint(w, l, "\r\n")
+		r = r[len(l):]
 		fmt.Fprint(w, " ")
 	}
 	for len(r) > 74 {
-		fmt.Fprint(w, r[:74], "\r\n")
-		r = r[74:]
+		l := trimUT8StringUpTo(74, r)
+		fmt.Fprint(w, l, "\r\n")
+		r = r[len(l):]
 		fmt.Fprint(w, " ")
 	}
 	fmt.Fprint(w, r, "\r\n")


### PR DESCRIPTION
When a line contains long UTF-8 characters (more than 1 octet), there is a chance to get invalid UTF8-string by cutting a line up to 75-th octet. It should be done more carefully by trimming up to the end of the last rune that doesn't overflow the 75 octet limit.

This pull request fixes this bug.