### PR TITLE
Implement attachment logic

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -30,6 +30,7 @@ const (
 	ComponentPropertyDtstamp      ComponentProperty = "DTSTAMP"
 	ComponentPropertyOrganizer    ComponentProperty = "ORGANIZER"
 	ComponentPropertyAttendee     ComponentProperty = "ATTENDEE"
+	ComponentPropertyAttach       ComponentProperty = "ATTACH"
 	ComponentPropertyDescription  ComponentProperty = "DESCRIPTION"
 	ComponentPropertyCategories   ComponentProperty = "CATEGORIES"
 	ComponentPropertyClass        ComponentProperty = "CLASS"

--- a/components.go
+++ b/components.go
@@ -2,6 +2,7 @@ package ics
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -141,6 +142,20 @@ func (event *VEvent) SetOrganizer(s string, props ...PropertyParameter) {
 
 func (event *VEvent) AddAttendee(s string, props ...PropertyParameter) {
 	event.AddProperty(ComponentPropertyAttendee, "mailto:"+s, props...)
+}
+
+func (event *VEvent) AddAttachment(s string, props ...PropertyParameter) {
+	event.AddProperty(ComponentPropertyAttach, s, props...)
+}
+
+func (event *VEvent) AddAttachmentURL(uri string, contentType string) {
+	event.AddAttachment(uri, WithFmtType(contentType))
+}
+
+func (event *VEvent) AddAttachmentBinary(binary []byte, contentType string) {
+	event.AddAttachment(base64.StdEncoding.EncodeToString(binary),
+		WithFmtType(contentType), WithEncoding("base64"), WithValue("binary"),
+	)
 }
 
 type Attendee struct {

--- a/property.go
+++ b/property.go
@@ -37,6 +37,27 @@ func WithCN(cn string) PropertyParameter {
 	}
 }
 
+func WithEncoding(encType string) PropertyParameter {
+	return &KeyValues{
+		Key:   string(ParameterEncoding),
+		Value: []string{encType},
+	}
+}
+
+func WithFmtType(contentType string) PropertyParameter {
+	return &KeyValues{
+		Key:   string(ParameterFmttype),
+		Value: []string{contentType},
+	}
+}
+
+func WithValue(kind string) PropertyParameter {
+	return &KeyValues{
+		Key:   string(ParameterValue),
+		Value: []string{kind},
+	}
+}
+
 func WithRSVP(b bool) PropertyParameter {
 	return &KeyValues{
 		Key:   string(ParameterRsvp),


### PR DESCRIPTION
It will be very useful, if this package has attachment logic implemented. It's kind of simple and well described here:
https://icalendar.org/iCalendar-RFC-5545/3-8-1-1-attachment.html

So I added handy wrappers to create reference and item attachments.