### PR TITLE
add linting action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,18 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.35

--- a/calendar.go
+++ b/calendar.go
@@ -476,7 +476,7 @@ func (cs *CalendarStream) ReadLine() (*ContentLine, error) {
 	for c {
 		var b []byte
 		b, err = cs.b.ReadBytes('\n')
-		if b == nil || len(b) == 0 {
+		if len(b) == 0 {
 			if err == nil {
 				continue
 			} else {

--- a/calendar.go
+++ b/calendar.go
@@ -357,7 +357,7 @@ func (calendar *Calendar) AddEvent(id string) *VEvent {
 	e := &VEvent{
 		ComponentBase{
 			Properties: []IANAProperty{
-				IANAProperty{BaseProperty{IANAToken: ToText(string(ComponentPropertyUniqueId)), Value: id}},
+				{BaseProperty{IANAToken: ToText(string(ComponentPropertyUniqueId)), Value: id}},
 			},
 		},
 	}

--- a/calendar.go
+++ b/calendar.go
@@ -495,7 +495,7 @@ func (cs *CalendarStream) ReadLine() (*ContentLine, error) {
 			if len(p) == 0 {
 				c = false
 			} else if p[0] == ' ' {
-				cs.b.Discard(1)
+				cs.b.Discard(1) // nolint:errcheck
 			} else {
 				c = false
 			}

--- a/components.go
+++ b/components.go
@@ -195,7 +195,7 @@ func (attendee *Attendee) ParticipationStatus() ParticipationStatus {
 
 func (attendee *Attendee) getPropertyFirst(parameter Parameter) string {
 	vs := attendee.getProperty(parameter)
-	if vs != nil && len(vs) > 0 {
+	if len(vs) > 0 {
 		return vs[0]
 	}
 	return ""

--- a/property.go
+++ b/property.go
@@ -172,7 +172,6 @@ func ParseProperty(contentLine ContentLine) *BaseProperty {
 			return nil
 		}
 	}
-	return nil
 }
 
 func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProperty, int) {
@@ -207,7 +206,6 @@ func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProper
 			return r, p
 		}
 	}
-	return nil, p
 }
 
 func parsePropertyValue(r *BaseProperty, contentLine string, p int) *BaseProperty {


### PR DESCRIPTION
This MR adds a linting action based on `golangci-lint` and it's corresponding action:
https://golangci-lint.run/usage/install/#github-actions

It will automatically comment in a pull request, if linting errors are found. The default config is used.

I corrected the found issues already in the corresponding commits.

An example run can be found here:
https://github.com/thde/golang-ical/runs/1679998134?check_suite_focus=true