### PR TITLE
Add missing space when folding lines

### DIFF
--- a/calendar_test.go
+++ b/calendar_test.go
@@ -119,7 +119,7 @@ func TestLineFolding(t *testing.T) {
 VERSION:2.0
 PRODID:-//arran4//Golang ICS Library
 DESCRIPTION:some really long line with spaces to fold on and the line
- should fold
+  should fold
 END:VCALENDAR
 `,
 		},
@@ -130,7 +130,7 @@ END:VCALENDAR
 VERSION:2.0
 PRODID:-//arran4//Golang ICS Library
 DESCRIPTION:somereallylonglinewithnospacestofoldonandthelineshouldfoldtothe
-nextline
+ nextline
 END:VCALENDAR
 `,
 		},
@@ -141,8 +141,8 @@ END:VCALENDAR
 VERSION:2.0
 PRODID:-//arran4//Golang ICS Library
 DESCRIPTION:some really long line with spaces
- howeverthelastpartofthelineisactuallytoolongtofitonsowehavetofoldpartwayt
-hrough
+  howeverthelastpartofthelineisactuallytoolongtofitonsowehavetofoldpartwayt
+ hrough
 END:VCALENDAR
 `,
 		},

--- a/property.go
+++ b/property.go
@@ -114,8 +114,12 @@ func (property *BaseProperty) serialize(w io.Writer) {
 	}
 	for len(r) > 74 {
 		l := trimUT8StringUpTo(74, r)
-		fmt.Fprint(w, l, "\r\n")
+		fmt.Fprint(w, " ", l, "\r\n")
 		r = r[len(l):]
+	}
+	// if the line was split insert an extra space
+	if b.Len() > 75 {
+		fmt.Fprint(w, " ")
 	}
 	fmt.Fprint(w, r, "\r\n")
 }


### PR DESCRIPTION
When folding lines to 75 characters a space should be inserted at the beginning of the new line, otherwise if the text is split around a space this space will be removed during parsing.

For example, parsing
```
DESCRIPTION:some really long line with spaces to fold on and the line
 should fold
```
will yield
```
some really long line with spaces to fold on and the lineshould fold
```

From the RFC:
> A long line can be split between any two characters by inserting a CRLF immediately followed by a single linear white-space character (i.e., SPACE or HTAB).  Any sequence of CRLF followed immediately by a single linear white-space character is ignored (i.e., removed) when processing the content type.