### PR TITLE
Fix line folding for 75 chars lines

### DIFF
--- a/property.go
+++ b/property.go
@@ -111,14 +111,12 @@ func (property *BaseProperty) serialize(w io.Writer) {
 		l := trimUT8StringUpTo(75, r)
 		fmt.Fprint(w, l, "\r\n")
 		r = r[len(l):]
-	}
-	for len(r) > 74 {
-		l := trimUT8StringUpTo(74, r)
-		fmt.Fprint(w, " ", l, "\r\n")
-		r = r[len(l):]
-	}
-	// if the line was split insert an extra space
-	if b.Len() > 75 {
+
+		for len(r) > 74 {
+			l := trimUT8StringUpTo(74, r)
+			fmt.Fprint(w, " ", l, "\r\n")
+			r = r[len(l):]
+		}
 		fmt.Fprint(w, " ")
 	}
 	fmt.Fprint(w, r, "\r\n")


### PR DESCRIPTION
Found a small issue following https://github.com/arran4/golang-ical/pull/39.
When the line is exactly 75 characters long, an extra space is inserted at the beginning of the line.

This is because the condition (`len > 75`) is ignored but then the loop condition (`len > 74`) would be true. I moved the loop inside the condition as it should only ever be needed if the line was originally longer than 75 chars.

Also added a test for that and moved the rune test with the other folding tests as I believe this is what it was originally testing, but let me know what you think 🙂 