### PR TITLE
add func to add an existing event to calendar

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -393,6 +393,7 @@ func (calendar *Calendar) setProperty(property Property, value string, props ...
 	}
 	calendar.CalendarProperties = append(calendar.CalendarProperties, r)
 }
+
 func (calendar *Calendar) AddEvent(id string) *VEvent {
 	e := &VEvent{
 		ComponentBase{
@@ -404,6 +405,11 @@ func (calendar *Calendar) AddEvent(id string) *VEvent {
 	calendar.Components = append(calendar.Components, e)
 	return e
 }
+
+func (calendar *Calendar) AddVEvent(e *VEvent) {
+	calendar.Components = append(calendar.Components, e)
+}
+
 func (calendar *Calendar) Events() (r []*VEvent) {
 	r = []*VEvent{}
 	for i := range calendar.Components {


### PR DESCRIPTION
**Description**
Add function to add existing events to a calendar.

**Background** 
This will be required because I want to add the same event to multiple calendars.
Currently I have to do it e.g. this way:

```go
// old way
e2 := ics.VEvent{}
e2.SetSummary("TestSum - old way")
c.Components = append(c.Components, &e2)
```

Another option also could be adding the already added event (`e := c1.AddEvent()`) to the second calendar (`c2.Compotents = append(c2.Components, &e)`).
In my opinion, both methods are not really elegant.

**New implementation**
Instead of using the unpleasant way by accessing Components directly it would be great to have another `AddEvent` function.
Therefore I added the function `AddVEvent` (naming suggestions are welcome here) to be able to add a existing event instead of creating a new one with `AddEvent`.

_(Also added some line breaks to separate functions)_

**Example**
The code works as follows:

```go
c := ics.NewCalendar()

// new way
e1 := ics.VEvent{}
e1.SetSummary("TestSum - new way")
c.AddVEvent(&e1)

// old way
e2 := ics.VEvent{}
e2.SetSummary("TestSum - old way")
c.Components = append(c.Components, &e2)

// regular way
e3 := c.AddEvent("1234")
e3.SetSummary("TestSum - regular way")

// print calendar
c_str := c.Serialize()
fmt.Println(c_str)
```

output:
```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//arran4//Golang ICS Library
BEGIN:VEVENT
SUMMARY:TestSum - new way
END:VEVENT
BEGIN:VEVENT
SUMMARY:TestSum - old way
END:VEVENT
BEGIN:VEVENT
UID:1234
SUMMARY:TestSum - regular way
END:VEVENT
END:VCALENDAR
```
	