### PR TITLE
add NewEvent function

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -393,14 +393,20 @@ func (calendar *Calendar) setProperty(property Property, value string, props ...
 	}
 	calendar.CalendarProperties = append(calendar.CalendarProperties, r)
 }
-func (calendar *Calendar) AddEvent(id string) *VEvent {
+
+func NewEvent(uniqueId string) *VEvent {
 	e := &VEvent{
 		ComponentBase{
 			Properties: []IANAProperty{
-				{BaseProperty{IANAToken: ToText(string(ComponentPropertyUniqueId)), Value: id}},
+				{BaseProperty{IANAToken: ToText(string(ComponentPropertyUniqueId)), Value: uniqueId}},
 			},
 		},
 	}
+	return e
+}
+
+func (calendar *Calendar) AddEvent(id string) *VEvent {
+	e := NewEvent(id)
 	calendar.Components = append(calendar.Components, e)
 	return e
 }


### PR DESCRIPTION
**Description** 
This will allow to create a event with uniqueId.

**Background**
Currently it is very easy to create a `VEvent` with `e := ics.VEvent{}`.
But there is a issue with setting the _uniqueId_.
This is not easy possible without a big efford which it should not be.

Unfortunally there is no direct function for changing the _uid_.
But it is probably better to address this functionality directly in the event creation anyway.

**New implementation**

- Adding function `NewEvent` to create a new event (having _uid_) without directly adding it to a calendar.
- Update `AddEvent` func to use new function.

**Example**
The code works as follows:

```go
c := ics.NewCalendar()

// new way
e1 := ics.NewEvent("id")
e1.SetSummary("new way")
c.Components = append(c.Components, e1)

// old way
e2 := ics.VEvent{}
e2.SetSummary("old way")
c.Components = append(c.Components, &e2)

// old way with id
id := "id"
e3 := ics.VEvent{
ics.ComponentBase{
	Properties: []ics.IANAProperty{
		{ics.BaseProperty{IANAToken: ics.ToText(string(ics.ComponentPropertyUniqueId)), Value: id}},
	},
},
}
e3.SetSummary("old way with id")
c.Components = append(c.Components, &e3)

// regular way
e4 := c.AddEvent("1234")
e4.SetSummary("TestSum - regular way")

// print calendar
c_str := c.Serialize()
fmt.Println(c_str)
```

output:
```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//arran4//Golang ICS Library
BEGIN:VEVENT
UID:id
SUMMARY:new way
END:VEVENT
BEGIN:VEVENT
SUMMARY:old way
END:VEVENT
BEGIN:VEVENT
UID:id
SUMMARY:old way with id
END:VEVENT
BEGIN:VEVENT
UID:1234
SUMMARY:TestSum - regular way
END:VEVENT
END:VCALENDAR
```

---

With #45 merged the event also can be added straightforward with:

```go
e5 := ics.NewEvent("id")
e5.SetSummary("with AddVEvent")
c.AddVEvent(e5)
```