### PR TITLE
add SetDuration for VEvent

### DIFF
--- a/components.go
+++ b/components.go
@@ -96,16 +96,19 @@ func (event *VEvent) SetAllDayEndAt(t time.Time, props ...PropertyParameter) {
 // The duration defines the length of a event relative to start or end time.
 //
 // Notice: It will not set the DURATION key of the ics - only DTSTART and DTEND will be affected.
-func (event *VEvent) SetDuration(d time.Duration) {
+func (event *VEvent) SetDuration(d time.Duration) error {
 	t, err := event.GetStartAt()
 	if err == nil {
 		event.SetEndAt(t.Add(d))
+		return nil
 	} else {
 		t, err = event.GetEndAt()
 		if err == nil {
 			event.SetStartAt(t.Add(-d))
+			return nil
 		}
 	}
+	return errors.New("start or end not yet defined")
 }
 
 func (event *VEvent) getTimeProp(componentProperty ComponentProperty, tFormat string) (time.Time, error) {

--- a/components.go
+++ b/components.go
@@ -91,6 +91,18 @@ func (event *VEvent) SetAllDayEndAt(t time.Time, props ...PropertyParameter) {
 	event.SetProperty(ComponentPropertyDtEnd, t.UTC().Format(icalAllDayTimeFormat), props...)
 }
 
+func (event *VEvent) SetDuration(d time.Duration) {
+	t, err := event.GetStartAt()
+	if err == nil {
+		event.SetEndAt(t.Add(d))
+	} else {
+		t, err = event.GetEndAt()
+		if err == nil {
+			event.SetStartAt(t.Add(-d))
+		}
+	}
+}
+
 func (event *VEvent) getTimeProp(componentProperty ComponentProperty, tFormat string) (time.Time, error) {
 	timeProp := event.GetProperty(componentProperty)
 	if timeProp == nil {

--- a/components.go
+++ b/components.go
@@ -91,6 +91,11 @@ func (event *VEvent) SetAllDayEndAt(t time.Time, props ...PropertyParameter) {
 	event.SetProperty(ComponentPropertyDtEnd, t.UTC().Format(icalAllDayTimeFormat), props...)
 }
 
+// SetDuration updates the duration of an event.
+// This function will set either the end or start time of an event depending what is already given.
+// The duration defines the length of a event relative to start or end time.
+//
+// Notice: It will not set the DURATION key of the ics - only DTSTART and DTEND will be affected.
 func (event *VEvent) SetDuration(d time.Duration) {
 	t, err := event.GetStartAt()
 	if err == nil {

--- a/components_test.go
+++ b/components_test.go
@@ -1,0 +1,60 @@
+package ics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetDuration(t *testing.T) {
+	date, _ := time.Parse(time.RFC822, time.RFC822)
+	duration := time.Duration(float64(time.Hour) * 2)
+
+	testCases := []struct {
+		name   string
+		start  time.Time
+		end    time.Time
+		output string
+	}{
+		{
+			name:  "test set duration - start",
+			start: date,
+			output: `BEGIN:VEVENT
+UID:test-duration
+DTSTART:20060102T150400Z
+DTEND:20060102T170400Z
+END:VEVENT
+`,
+		},
+		{
+			name: "test set duration - end",
+			end:  date,
+			output: `BEGIN:VEVENT
+UID:test-duration
+DTEND:20060102T150400Z
+DTSTART:20060102T130400Z
+END:VEVENT
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEvent("test-duration")
+			if !tc.start.IsZero() {
+				e.SetStartAt(tc.start)
+			}
+			if !tc.end.IsZero() {
+				e.SetEndAt(tc.end)
+			}
+			e.SetDuration(duration)
+
+			// we're not testing for encoding here so lets make the actual output line breaks == expected line breaks
+			text := strings.Replace(e.Serialize(), "\r\n", "\n", -1)
+
+			assert.Equal(t, tc.output, text)
+		})
+	}
+}

--- a/components_test.go
+++ b/components_test.go
@@ -49,12 +49,13 @@ END:VEVENT
 			if !tc.end.IsZero() {
 				e.SetEndAt(tc.end)
 			}
-			e.SetDuration(duration)
+			err := e.SetDuration(duration)
 
 			// we're not testing for encoding here so lets make the actual output line breaks == expected line breaks
 			text := strings.Replace(e.Serialize(), "\r\n", "\n", -1)
 
 			assert.Equal(t, tc.output, text)
+			assert.Equal(t, nil, err)
 		})
 	}
 }


### PR DESCRIPTION
**Description**
Add function to add a event duration after start or end was already set.

This helps to simple add a `time.Duration` value to the event instead of manually calculating the event end time.

**New implementation**
This implementation will check if a start time is already set and will add the duration to this time.
If the start time is not present it will try to check if the end time is instead set.
When this is the case the duration will be subtracted from the end time.

**Problems**
If no time is set yet (no `SetStartAt` or `SetEndAt` called) nothing will happen.
The time will be required before - therefore the order is important.

Another implementation would be to deviate from the standart which maybe require a workaround.
In my opinion it should not be that big problem because usually you would try first to set start time and add the duration afterwards.

Another problem is that this implementation does NOT use the [RFC duration](https://datatracker.ietf.org/doc/html/rfc5545#section-3.3.6) - instead it will calculate the start/end time.
When implementing a duration (e.g. `DURATION:PT1H30M`) and start and end are both set it will fail to import the calendar on _MacOS Calendar_ (not sure if it is allowed by RFC or just not work on Mac).
It is only possible to use `DTSTART` and `DURATION` at the same time here.

examples:

<details>
<summary>DTSTART, DTEND and DURATION (fail)</summary>

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//arran4//Golang ICS Library
BEGIN:VEVENT
UID:1111
SUMMARY:Test
DTSTART:20211208T203000Z
DTEND:20211208T220000Z
DURATION:PT1H30M
END:VEVENT
END:VCALENDAR
```

</details>

<details>
<summary>DTSTART and DURATION (success)</summary>

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//arran4//Golang ICS Library
BEGIN:VEVENT
UID:1111
SUMMARY:Test
DTSTART:20211208T203000Z
DURATION:PT1H30M
END:VEVENT
END:VCALENDAR
```

</details>

Therefore it might be better to use this implementation instead of using the `PropertyDuration`.

It would be great to discuss this issue in this PR or a separate issue.

**Example**

```go
c := ics.NewCalendar()

duration := time.Duration(float64(time.Hour) * 2)

start := time.Now()

// old way
e1 := c.AddEvent("1111")
e1.SetSummary("old way")
e1.SetStartAt(start)
e1.SetEndAt(start.Add(duration))

// new way - start
e2 := c.AddEvent("2222")
e2.SetSummary("new way start")
e2.SetStartAt(start)
e2.SetDuration(duration)

// new way - end
e3 := c.AddEvent("3333")
e3.SetSummary("new way end")
e3.SetEndAt(start)
e3.SetDuration(duration)

// print
c_str := c.Serialize()
fmt.Println(c_str)
```

output:

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//arran4//Golang ICS Library
BEGIN:VEVENT
UID:1111
SUMMARY:old way
DTSTART:20211208T194700Z
DTEND:20211208T214700Z
END:VEVENT
BEGIN:VEVENT
UID:2222
SUMMARY:new way start
DTSTART:20211208T194700Z
DTEND:20211208T214700Z
END:VEVENT
BEGIN:VEVENT
UID:3333
SUMMARY:new way end
DTEND:20211208T194700Z
DTSTART:20211208T174700Z
END:VEVENT
END:VCALENDAR
```
