### PR TITLE
fix: also escape comma and (semi-)colon

### DIFF
--- a/property.go
+++ b/property.go
@@ -98,8 +98,11 @@ func (property *BaseProperty) serialize(w io.Writer) {
 				fmt.Fprint(b, ",")
 			}
 			if strings.ContainsAny(v, ";:\\\",") {
-				v = strings.Replace(v, "\"", "\\\"", -1)
+				v = strings.Replace(v, ";", "\\;", -1)
+				v = strings.Replace(v, ":", "\\:", -1)
 				v = strings.Replace(v, "\\", "\\\\", -1)
+				v = strings.Replace(v, "\"", "\\\"", -1)
+				v = strings.Replace(v, ",", "\\,", -1)
 			}
 			fmt.Fprint(b, v)
 		}


### PR DESCRIPTION
Hi,

Google Calendar had problems to import my .ics file serialized with `golang-ical`. 
I saw that commas are not escaped, although the 
```go
if strings.ContainsAny(v, ";:\\",") {
```
check suggests that commas should be serialized as well. 
After I added the changes, Google Calendar accepted my .ics file.

Now the question: Is this how it should be, or is something else wrong here?

```markdown
# works
ORGANIZER;CN=Lastname\, Firstname:MAILTO:xyz@example.com

# doesn't work
ORGANIZER;CN=Lastname, Firstname:MAILTO:xyz@example.com
```