### PR TITLE
Added godoc sticker to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # golang-ical
 A  ICS / ICal parser and serialiser for Golang.
 
+[![GoDoc](https://godoc.org/github.com/arran4/golang-ical?status.svg)](https://godoc.org/github.com/arran4/golang-ical)
+
 Because the other libraries didn't quite do what I needed.
 
 Usage, parsing:


### PR DESCRIPTION
This PR adds a sticker to the README that links to the pkg.go.dev documentation page that was automatically generated by go. This allows for the documentation to be pulled up easier without pasting the url into the site

A preview of the sticker can be found on my branch [here](https://github.com/NickyBoy89/golang-ical/tree/added-godot-sticker)