### PR TITLE
fix: omit zone in "AllDay" event helpers

### DIFF
--- a/components_test.go
+++ b/components_test.go
@@ -64,16 +64,36 @@ func TestSetAllDay(t *testing.T) {
 	date, _ := time.Parse(time.RFC822, time.RFC822)
 
 	testCases := []struct {
-		name   string
-		start  time.Time
-		end    time.Time
-		output string
+		name     string
+		start    time.Time
+		end      time.Time
+		duration time.Duration
+		output   string
 	}{
 		{
-			name:  "test set duration - start",
+			name:  "test set all day - start",
 			start: date,
 			output: `BEGIN:VEVENT
-UID:test-duration
+UID:test-allday
+DTSTART;VALUE=DATE:20060102
+END:VEVENT
+`,
+		},
+		{
+			name: "test set all day - end",
+			end:  date,
+			output: `BEGIN:VEVENT
+UID:test-allday
+DTEND;VALUE=DATE:20060102
+END:VEVENT
+`,
+		},
+		{
+			name:     "test set all day - duration",
+			start:    date,
+			duration: time.Hour * 24,
+			output: `BEGIN:VEVENT
+UID:test-allday
 DTSTART;VALUE=DATE:20060102
 DTEND;VALUE=DATE:20060103
 END:VEVENT
@@ -83,12 +103,19 @@ END:VEVENT
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			e := NewEvent("test-duration")
-			e.SetAllDayStartAt(date)
-			e.SetAllDayEndAt(date.AddDate(0, 0, 1))
+			e := NewEvent("test-allday")
+			if !tc.start.IsZero() {
+				e.SetAllDayStartAt(tc.start)
+			}
+			if !tc.end.IsZero() {
+				e.SetAllDayEndAt(tc.end)
+			}
+			if tc.duration != 0 {
+				err := e.SetDuration(tc.duration)
+				assert.NoError(t, err)
+			}
 
-			// we're not testing for encoding here so lets make the actual output line breaks == expected line breaks
-			text := strings.Replace(e.Serialize(), "\r\n", "\n", -1)
+			text := strings.ReplaceAll(e.Serialize(), "\r\n", "\n")
 
 			assert.Equal(t, tc.output, text)
 		})

--- a/property.go
+++ b/property.go
@@ -86,6 +86,17 @@ func trimUT8StringUpTo(maxLength int, s string) string {
 	return s[:length]
 }
 
+func (property *BaseProperty) parameterValue(param Parameter) (string, error) {
+	v, ok := property.ICalParameters[string(param)]
+	if !ok || len(v) == 0 {
+		return "", fmt.Errorf("parameter %q not found in property", param)
+	}
+	if len(v) != 1 {
+		return "", fmt.Errorf("expected only one value for parameter %q in property, found %d", param, len(v))
+	}
+	return v[0], nil
+}
+
 func (property *BaseProperty) serialize(w io.Writer) {
 	b := bytes.NewBufferString("")
 	fmt.Fprint(b, property.IANAToken)


### PR DESCRIPTION
For a date-only event (i.e., an event that lasts for the full day) the iCalendar specification indicates that the value for DTSTART / DTEND should be a DATE

https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html

> The "VEVENT" is also the calendar component used to specify an
> anniversary or daily reminder within a calendar. These events have a
> DATE value type for the "DTSTART" property instead of the default value
> type of DATE-TIME. If such a "VEVENT" has a "DTEND" property, it MUST be
> specified as a DATE value also

The DATE format
(https://icalendar.org/iCalendar-RFC-5545/3-3-4-date.html) should omit both time and zone/location elements and additionally notes that "The "TZID" property parameter MUST NOT be applied to DATE properties"

As per the specification, this PR also adds an explicit "VALUE=DATE" parameter when the AllDay helpers were called, to indicate that the property's default value type has been overridden and the VEVENT is intended to be an all-day event
https://icalendar.org/iCalendar-RFC-5545/3-2-20-value-data-types.html

Finally the SetDuration call has been updated to preserve the "AllDay" characteristics if the existing start or end has been specified in DATE format, which is also a requirement of the spec.

Contributes-to: #55