### PR TITLE
fix format when setting all day

### DIFF
--- a/components.go
+++ b/components.go
@@ -126,7 +126,8 @@ func (event *VEvent) SetStartAt(t time.Time, props ...PropertyParameter) {
 }
 
 func (event *VEvent) SetAllDayStartAt(t time.Time, props ...PropertyParameter) {
-	event.SetProperty(ComponentPropertyDtStart, t.UTC().Format(icalDateFormatUtc), props...)
+	props = append(props, WithValue(string(ValueDataTypeDate)))
+	event.SetProperty(ComponentPropertyDtStart, t.Format(icalDateFormatLocal), props...)
 }
 
 func (event *VEvent) SetEndAt(t time.Time, props ...PropertyParameter) {
@@ -134,7 +135,8 @@ func (event *VEvent) SetEndAt(t time.Time, props ...PropertyParameter) {
 }
 
 func (event *VEvent) SetAllDayEndAt(t time.Time, props ...PropertyParameter) {
-	event.SetProperty(ComponentPropertyDtEnd, t.UTC().Format(icalDateFormatUtc), props...)
+	props = append(props, WithValue(string(ValueDataTypeDate)))
+	event.SetProperty(ComponentPropertyDtEnd, t.Format(icalDateFormatLocal), props...)
 }
 
 // SetDuration updates the duration of an event.

--- a/components_test.go
+++ b/components_test.go
@@ -59,3 +59,38 @@ END:VEVENT
 		})
 	}
 }
+
+func TestSetAllDay(t *testing.T) {
+	date, _ := time.Parse(time.RFC822, time.RFC822)
+
+	testCases := []struct {
+		name   string
+		start  time.Time
+		end    time.Time
+		output string
+	}{
+		{
+			name:  "test set duration - start",
+			start: date,
+			output: `BEGIN:VEVENT
+UID:test-duration
+DTSTART;VALUE=DATE:20060102
+DTEND;VALUE=DATE:20060103
+END:VEVENT
+`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := NewEvent("test-duration")
+			e.SetAllDayStartAt(date)
+			e.SetAllDayEndAt(date.AddDate(0, 0, 1))
+
+			// we're not testing for encoding here so lets make the actual output line breaks == expected line breaks
+			text := strings.Replace(e.Serialize(), "\r\n", "\n", -1)
+
+			assert.Equal(t, tc.output, text)
+		})
+	}
+}


### PR DESCRIPTION
Using the implementation from https://github.com/arran4/golang-ical/pull/61 however removing the call to `UTC()`, `time.Time` already holds timezone information so users can set the location using `In(tz)` on the `time.Time` object itself.