### PR TITLE
URL support for parsing (issue #77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ A  ICS / ICal parser and serialiser for Golang.
 Because the other libraries didn't quite do what I needed.
 
 Usage, parsing:
-```
+```golang
     cal, err := ParseCalendar(strings.NewReader(input))
 
 ```
 
-Creating:
+Usage, parsing from a URL :
+```golang
+    cal, err := ParseCalendar("an-ics-url")
 ```
+
+Creating:
+```golang
   cal := ics.NewCalendar()
   cal.SetMethod(ics.MethodRequest)
   event := cal.AddEvent(fmt.Sprintf("id@domain", p.SessionKey.IntID()))

--- a/calendar.go
+++ b/calendar.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"time"
 )
 
@@ -434,6 +435,23 @@ func (calendar *Calendar) Events() (r []*VEvent) {
 		}
 	}
 	return
+}
+
+func ParseCalendarFromUrl(url string) (*Calendar, error) {
+	http_client := &http.Client{}
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := http_client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return ParseCalendar(resp.Body)
 }
 
 func ParseCalendar(r io.Reader) (*Calendar, error) {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -1,7 +1,6 @@
 package ics
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimeParsing(t *testing.T) {
@@ -359,4 +360,16 @@ func TestIssue52(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read test directory: %v", err)
 	}
+}
+
+func TestIssue77(t *testing.T) {
+	url := "https://proseconsult.umontpellier.fr/jsp/custom/modules/plannings/direct_cal.jsp?data=58c99062bab31d256bee14356aca3f2423c0f022cb9660eba051b2653be722c4c7f281e4e3ad06b85d3374100ac416a4dc5c094f7d1a811b903031bde802c7f50e0bd1077f9461bed8f9a32b516a3c63525f110c026ed6da86f487dd451ca812c1c60bb40b1502b6511435cf9908feb2166c54e36382c1aa3eb0ff5cb8980cdb,1"
+
+	cal, err := ParseCalendarFromUrl(url)
+
+	if err != nil {
+		t.Fatalf("Error reading file: %s", err)
+	}
+
+	t.Log(cal.CalendarProperties)
 }


### PR DESCRIPTION
In response to issue #77, I have made some improvements to the codebase. Specifically, I have added a new method `ParseCalendarFromUrl(string)` and a new test case that verifies the absence of errors when invoking this method.

Currently, this method initializes a basic `http.Client` and forwards the response body to the `ParseCalendar(string)` function. However, as suggested in issue #77, it may be beneficial to allow users to use a custom `http.Client` to address authentication, CORS, and similar concerns.

I am currently exploring the best design approach to accommodate this feature request. Any input or suggestions on the optimal design for this enhancement would be greatly appreciated.