### PR TITLE
Add VEvent.GetDtStampTime

### DIFF
--- a/components.go
+++ b/components.go
@@ -242,6 +242,10 @@ func (event *VEvent) GetAllDayEndAt() (time.Time, error) {
 	return event.getTimeProp(ComponentPropertyDtEnd, true)
 }
 
+func (event *VEvent) GetDtStampTime() (time.Time, error) {
+	return event.getTimeProp(ComponentPropertyDtstamp, false)
+}
+
 type TimeTransparency string
 
 const (


### PR DESCRIPTION
This is related to issue https://github.com/arran4/golang-ical/issues/79.

> Add VEvent.GetDtStampTime as a partner to VEvent.SetDtStampTime. It is currently possible to read out the value using GetProperty, but the getTimeProp helper function -- that is used to parse different time formats for other get methods -- is not exported.

This adds VEvent.GetDtStampTime.