### PR TITLE
Add {Get,Set}LastModifiedAt helpers

### DIFF
--- a/components.go
+++ b/components.go
@@ -139,6 +139,10 @@ func (event *VEvent) SetAllDayEndAt(t time.Time, props ...PropertyParameter) {
 	event.SetProperty(ComponentPropertyDtEnd, t.Format(icalDateFormatLocal), props...)
 }
 
+func (event *VEvent) SetLastModifiedAt(t time.Time, props ...PropertyParameter) {
+	event.SetProperty(ComponentPropertyLastModified, t.UTC().Format(icalTimestampFormatUtc), props...)
+}
+
 // SetDuration updates the duration of an event.
 // This function will set either the end or start time of an event depending what is already given.
 // The duration defines the length of a event relative to start or end time.
@@ -232,6 +236,10 @@ func (event *VEvent) GetStartAt() (time.Time, error) {
 
 func (event *VEvent) GetEndAt() (time.Time, error) {
 	return event.getTimeProp(ComponentPropertyDtEnd, false)
+}
+
+func (event *VEvent) GetLastModifiedAt() (time.Time, error) {
+	return event.getTimeProp(ComponentPropertyLastModified, false)
 }
 
 func (event *VEvent) GetAllDayStartAt() (time.Time, error) {

--- a/components_test.go
+++ b/components_test.go
@@ -94,3 +94,17 @@ END:VEVENT
 		})
 	}
 }
+
+func TestGetLastModifiedAt(t *testing.T) {
+	e := NewEvent("test-last-modified")
+	lastModified := time.Unix(123456789, 0)
+	e.SetLastModifiedAt(lastModified)
+	got, err := e.GetLastModifiedAt()
+	if err != nil {
+		t.Fatalf("e.GetLastModifiedAt: %v", err)
+	}
+
+	if !got.Equal(lastModified) {
+		t.Errorf("got last modified = %q, want %q", got, lastModified)
+	}
+}


### PR DESCRIPTION
Adding some helpers for parsing another timestamp field. I originally considered exposing `getTimeProp` as `ParseTimeProp`, but the ergonomics are weird enough (is the prop nil? should it be all-day-able?) that I decided against it.
