### PR TITLE
Fix several panics in ParseCalendar

### DIFF
--- a/calendar_fuzz_test.go
+++ b/calendar_fuzz_test.go
@@ -1,0 +1,22 @@
+//go:build go1.18
+// +build go1.18
+
+package ics
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzParseCalendar(f *testing.F) {
+	ics, err := os.ReadFile("testdata/timeparsing.ics")
+	require.NoError(f, err)
+	f.Add(ics)
+	f.Fuzz(func(t *testing.T, ics []byte) {
+		_, err := ParseCalendar(bytes.NewReader(ics))
+		t.Log(err)
+	})
+}

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -1,7 +1,7 @@
 package ics
 
 import (
-	"github.com/stretchr/testify/assert"
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTimeParsing(t *testing.T) {
@@ -359,4 +362,14 @@ func TestIssue52(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read test directory: %v", err)
 	}
+}
+
+func FuzzParseCalendar(f *testing.F) {
+	ics, err := os.ReadFile("testdata/timeparsing.ics")
+	require.NoError(f, err)
+	f.Add(ics)
+	f.Fuzz(func(t *testing.T, ics []byte) {
+		_, err := ParseCalendar(bytes.NewReader(ics))
+		t.Log(err)
+	})
 }

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -1,7 +1,7 @@
 package ics
 
 import (
-	"bytes"
+	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,9 +11,6 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTimeParsing(t *testing.T) {
@@ -362,14 +359,4 @@ func TestIssue52(t *testing.T) {
 	if err != nil {
 		t.Fatalf("cannot read test directory: %v", err)
 	}
-}
-
-func FuzzParseCalendar(f *testing.F) {
-	ics, err := os.ReadFile("testdata/timeparsing.ics")
-	require.NoError(f, err)
-	f.Add(ics)
-	f.Fuzz(func(t *testing.T, ics []byte) {
-		_, err := ParseCalendar(bytes.NewReader(ics))
-		t.Log(err)
-	})
 }

--- a/property.go
+++ b/property.go
@@ -194,6 +194,9 @@ func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProper
 	k, v := "", ""
 	k = string(contentLine[p : p+tokenPos[1]])
 	p += tokenPos[1]
+	if p >= len(contentLine) {
+		return nil, p, fmt.Errorf("missing property param operator for %s in %s", k, r.IANAToken)
+	}
 	switch rune(contentLine[p]) {
 	case '=':
 		p += 1

--- a/property.go
+++ b/property.go
@@ -2,6 +2,7 @@ package ics
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -264,6 +265,9 @@ func parsePropertyParamValue(s string, p int) (string, int, error) {
 			0x1C, 0x1D, 0x1E, 0x1F:
 			return "", 0, fmt.Errorf("unexpected char ascii:%d in property param value", s[p])
 		case '\\':
+			if p+2 >= len(s) {
+				return "", 0, errors.New("unexpected end of param value")
+			}
 			r = append(r, []byte(FromText(string(s[p+1:p+2])))...)
 			p++
 			continue

--- a/property.go
+++ b/property.go
@@ -213,6 +213,9 @@ func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProper
 			return nil, 0, fmt.Errorf("parse error: %w %s in %s", err, k, r.IANAToken)
 		}
 		r.ICalParameters[k] = append(r.ICalParameters[k], v)
+		if p >= len(contentLine) {
+			return nil, p, fmt.Errorf("unexpected end of property %s", r.IANAToken)
+		}
 		switch rune(contentLine[p]) {
 		case ',':
 			p += 1

--- a/testdata/fuzz/FuzzParseCalendar/5940bf4f62ecac30
+++ b/testdata/fuzz/FuzzParseCalendar/5940bf4f62ecac30
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0;0=\\")

--- a/testdata/fuzz/FuzzParseCalendar/5f69bd55acfce1af
+++ b/testdata/fuzz/FuzzParseCalendar/5f69bd55acfce1af
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0;0")

--- a/testdata/fuzz/FuzzParseCalendar/8856e23652c60ed6
+++ b/testdata/fuzz/FuzzParseCalendar/8856e23652c60ed6
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0;0=0")


### PR DESCRIPTION
I was trying to Fuzz [webcal-proxy](https://github.com/brackendawson/webcal-proxy) but I need golang-ical to be panic free first.