### PR TITLE
Fix various text escaping issues

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -317,7 +317,7 @@ func (calendar *Calendar) SerializeTo(w io.Writer) error {
 }
 
 func (calendar *Calendar) SetMethod(method Method, props ...PropertyParameter) {
-	calendar.setProperty(PropertyMethod, ToText(string(method)), props...)
+	calendar.setProperty(PropertyMethod, string(method), props...)
 }
 
 func (calendar *Calendar) SetXPublishedTTL(s string, props ...PropertyParameter) {
@@ -325,11 +325,11 @@ func (calendar *Calendar) SetXPublishedTTL(s string, props ...PropertyParameter)
 }
 
 func (calendar *Calendar) SetVersion(s string, props ...PropertyParameter) {
-	calendar.setProperty(PropertyVersion, ToText(s), props...)
+	calendar.setProperty(PropertyVersion, s, props...)
 }
 
 func (calendar *Calendar) SetProductId(s string, props ...PropertyParameter) {
-	calendar.setProperty(PropertyProductId, ToText(s), props...)
+	calendar.setProperty(PropertyProductId, s, props...)
 }
 
 func (calendar *Calendar) SetName(s string, props ...PropertyParameter) {
@@ -358,7 +358,7 @@ func (calendar *Calendar) SetXWRCalID(s string, props ...PropertyParameter) {
 }
 
 func (calendar *Calendar) SetDescription(s string, props ...PropertyParameter) {
-	calendar.setProperty(PropertyDescription, ToText(s), props...)
+	calendar.setProperty(PropertyDescription, s, props...)
 }
 
 func (calendar *Calendar) SetLastModified(t time.Time, props ...PropertyParameter) {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -1,7 +1,6 @@
 package ics
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"testing"
 	"time"
 	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTimeParsing(t *testing.T) {
@@ -312,6 +313,31 @@ PRODID:-//arran4//Golang ICS Library
 DESCRIPTION:test
 BEGIN:VEVENT
 DESCRIPTION:blablablablablablablablablablablablablablablabltesttesttest
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+`,
+		},
+		{
+			name: "test semicolon in attendee property parameter",
+			input: `BEGIN:VCALENDAR
+VERSION:2.0
+X-CUSTOM-FIELD:test
+PRODID:-//arran4//Golang ICS Library
+DESCRIPTION:test
+BEGIN:VEVENT
+ATTENDEE;CN=Test\;User:mailto:user@example.com
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+`,
+			output: `BEGIN:VCALENDAR
+VERSION:2.0
+X-CUSTOM-FIELD:test
+PRODID:-//arran4//Golang ICS Library
+DESCRIPTION:test
+BEGIN:VEVENT
+ATTENDEE;CN=Test\;User:mailto:user@example.com
 CLASS:PUBLIC
 END:VEVENT
 END:VCALENDAR

--- a/components.go
+++ b/components.go
@@ -214,19 +214,19 @@ func (cb *ComponentBase) GetDtStampTime() (time.Time, error) {
 }
 
 func (cb *ComponentBase) SetSummary(s string, props ...PropertyParameter) {
-	cb.SetProperty(ComponentPropertySummary, ToText(s), props...)
+	cb.SetProperty(ComponentPropertySummary, s, props...)
 }
 
 func (cb *ComponentBase) SetStatus(s ObjectStatus, props ...PropertyParameter) {
-	cb.SetProperty(ComponentPropertyStatus, ToText(string(s)), props...)
+	cb.SetProperty(ComponentPropertyStatus, string(s), props...)
 }
 
 func (cb *ComponentBase) SetDescription(s string, props ...PropertyParameter) {
-	cb.SetProperty(ComponentPropertyDescription, ToText(s), props...)
+	cb.SetProperty(ComponentPropertyDescription, s, props...)
 }
 
 func (cb *ComponentBase) SetLocation(s string, props ...PropertyParameter) {
-	cb.SetProperty(ComponentPropertyLocation, ToText(s), props...)
+	cb.SetProperty(ComponentPropertyLocation, s, props...)
 }
 
 func (cb *ComponentBase) setGeo(lat interface{}, lng interface{}, props ...PropertyParameter) {

--- a/property.go
+++ b/property.go
@@ -99,9 +99,9 @@ func (property *BaseProperty) serialize(w io.Writer) {
 				fmt.Fprint(b, ",")
 			}
 			if strings.ContainsAny(v, ";:\\\",") {
+				v = strings.Replace(v, "\\", "\\\\", -1)
 				v = strings.Replace(v, ";", "\\;", -1)
 				v = strings.Replace(v, ":", "\\:", -1)
-				v = strings.Replace(v, "\\", "\\\\", -1)
 				v = strings.Replace(v, "\"", "\\\"", -1)
 				v = strings.Replace(v, ",", "\\,", -1)
 			}

--- a/property.go
+++ b/property.go
@@ -109,7 +109,7 @@ func (property *BaseProperty) serialize(w io.Writer) {
 		}
 	}
 	fmt.Fprint(b, ":")
-	fmt.Fprint(b, property.Value)
+	fmt.Fprint(b, ToText(property.Value))
 	r := b.String()
 	if len(r) > 75 {
 		l := trimUT8StringUpTo(75, r)


### PR DESCRIPTION
1. Make sure that text escapes are handled correctly in all cases.
2. Normalize `property.Value` to always contain unescaped values. They are escaped when serializing, and unescaped when parsing.