### PR TITLE
Re-add Calendar.RemoveEvent method

### DIFF
--- a/components.go
+++ b/components.go
@@ -413,6 +413,22 @@ func (calendar *Calendar) AddVEvent(e *VEvent) {
 	calendar.Components = append(calendar.Components, e)
 }
 
+func (calendar *Calendar) RemoveEvent(id string) {
+	for i := range calendar.Components {
+		switch event := calendar.Components[i].(type) {
+		case *VEvent:
+			if event.Id() == id {
+				if len(calendar.Components) > i+1 {
+					calendar.Components = append(calendar.Components[:i], calendar.Components[i+1:]...)
+				} else {
+					calendar.Components = calendar.Components[:i]
+				}
+				return
+			}
+		}
+	}
+}
+
 func (calendar *Calendar) Events() (r []*VEvent) {
 	r = []*VEvent{}
 	for i := range calendar.Components {


### PR DESCRIPTION
The `RemoveEvent` method I added in #88 was (I assume accidentally) dropped in #84
As it seems there were some problems merging #66 and it then dropped the method.
Could we please re-add it.