### PR TITLE
Fixed parse URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Usage, parsing:
 
 ```
 
-Usage, parsing from a URL :
+Usage, parsing from a URL:
 ```golang
-    cal, err := ParseCalendar("an-ics-url")
+    cal, err := ParseCalendarFromUrl("https://your-ics-url")
 ```
 
 Creating:


### PR DESCRIPTION
I noticed the example in the README uses the wrong method. This PR fixes this.