### PR TITLE
Added RRULE parsing and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,114 @@ Creating:
 
 Helper methods created as needed feel free to send a P.R. with more.
 
+# Working with Recurring Events
+
+This library parses and provides typed access to recurrence properties (`RRULE`, `RDATE`, `EXDATE`, `EXRULE`, `RECURRENCE-ID`) but does not expand them into concrete occurrence dates.
+This keeps the library dependency-free and lets callers choose their own expansion strategy.
+
+## Accessing recurrence properties
+
+```golang
+  // Parse RRULE into a structured type
+  rules, err := event.GetRRules()
+  for _, rule := range rules {
+      fmt.Println(rule.Freq)       // e.g. ics.FrequencyYearly
+      fmt.Println(rule.ByMonth)    // e.g. [10]
+      fmt.Println(rule.ByDay)      // e.g. [{OrdWeek:-1 Day:SU}]
+      fmt.Println(rule.Count)      // e.g. 10
+      fmt.Println(rule.Interval)   // e.g. 1
+  }
+
+  // Get excluded dates (handles comma-separated values and multiple properties)
+  exDates, err := event.GetExDates()    // []time.Time
+  rDates, err := event.GetRDates()      // []time.Time
+
+  // Get recurrence ID (for modified/cancelled occurrences)
+  recID, err := event.GetRecurrenceID() // time.Time
+
+  // Serialize a RecurrenceRule back to RRULE format
+  rule, _ := ics.ParseRecurrenceRule("FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR")
+  fmt.Println(rule.String()) // "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"
+```
+
+## Expanding occurrences with rrule-go
+
+To expand recurring events into concrete dates, use a library like [rrule-go](https://github.com/teambition/rrule-go):
+
+```golang
+  import (
+      "github.com/arran4/golang-ical"
+      "github.com/teambition/rrule-go"
+  )
+
+  // Parse your calendar
+  cal, _ := ics.ParseCalendar(reader)
+
+  for _, event := range cal.Events() {
+      dtstart, _ := event.GetStartAt()
+      dtend, _ := event.GetEndAt()
+      duration := dtend.Sub(dtstart)
+
+      // Build an RRuleSet from the event's recurrence properties
+      set := &rrule.Set{}
+
+      rules, _ := event.GetRRules()
+      for _, r := range rules {
+          rr, _ := rrule.StrToRRule(r.String())
+          rr.DTStart(dtstart)
+          set.RRule(rr)
+      }
+
+      rDates, _ := event.GetRDates()
+      for _, rd := range rDates {
+          set.RDate(rd)
+      }
+
+      exDates, _ := event.GetExDates()
+      for _, exd := range exDates {
+          set.ExDate(exd)
+      }
+
+      // Get all occurrences in a time range
+      occurrences := set.Between(rangeStart, rangeEnd, true)
+
+      // Each occurrence is a start time; compute the end from the original duration
+      for _, occ := range occurrences {
+          fmt.Printf("  %s to %s\n", occ, occ.Add(duration))
+      }
+  }
+```
+
+### Handling RECURRENCE-ID overrides
+
+Calendar feeds use `RECURRENCE-ID` to modify or cancel individual occurrences of a recurring event.
+These appear as separate VEVENTs with the same UID but a `RECURRENCE-ID` property indicating which occurrence they replace.
+
+```golang
+  type overrideKey struct {
+      UID   string
+      Start time.Time
+  }
+
+  overrides := map[overrideKey]*ics.VEvent{}
+  var regularEvents []*ics.VEvent
+
+  for _, event := range cal.Events() {
+      recID, err := event.GetRecurrenceID()
+      if err == nil {
+          uid := event.GetProperty(ics.ComponentPropertyUniqueId).Value
+          overrides[overrideKey{UID: uid, Start: recID}] = event
+      } else {
+          regularEvents = append(regularEvents, event)
+      }
+  }
+
+  // After expanding occurrences from regularEvents, check each generated
+  // occurrence against the overrides map. If a match is found, replace that
+  // occurrence with the override's times/properties (or remove it if the
+  // override represents a cancellation).
+```
+
 # Notice
 
 Looking for a co-maintainer.

--- a/components.go
+++ b/components.go
@@ -279,7 +279,12 @@ func (cb *ComponentBase) getTimeProp(componentProperty ComponentProperty, expect
 		return time.Time{}, fmt.Errorf("%w: %s", ErrorPropertyNotFound, componentProperty)
 	}
 
-	timeVal := timeProp.BaseProperty.Value
+	return parseTimeValue(timeProp.BaseProperty.Value, timeProp.ICalParameters, expectAllDay)
+}
+
+// parseTimeValue parses a single iCal time value string with the given parameters.
+// This is the core time parsing logic shared by getTimeProp and multi-value time getters.
+func parseTimeValue(timeVal string, params map[string][]string, expectAllDay bool) (time.Time, error) {
 	matched := timeStampVariations.FindStringSubmatch(timeVal)
 	if matched == nil {
 		return time.Time{}, fmt.Errorf("time value not matched, got '%s'", timeVal)
@@ -289,7 +294,7 @@ func (cb *ComponentBase) getTimeProp(componentProperty ComponentProperty, expect
 	grp1len := len(matched[1])
 	grp3len := len(matched[3])
 
-	tzId, tzIdOk := timeProp.ICalParameters["TZID"]
+	tzId, tzIdOk := params["TZID"]
 	var propLoc *time.Location
 	if tzIdOk {
 		if len(tzId) != 1 {
@@ -355,6 +360,82 @@ func (cb *ComponentBase) GetLastModifiedAt() (time.Time, error) {
 
 func (cb *ComponentBase) GetDtStampTime() (time.Time, error) {
 	return cb.getTimeProp(ComponentPropertyDtstamp, false)
+}
+
+// GetRRules returns all RRULE properties parsed into RecurrenceRule structs.
+func (cb *ComponentBase) GetRRules() ([]*RecurrenceRule, error) {
+	return cb.getRecurrenceRules(ComponentPropertyRrule)
+}
+
+// GetExRules returns all EXRULE properties parsed into RecurrenceRule structs.
+func (cb *ComponentBase) GetExRules() ([]*RecurrenceRule, error) {
+	return cb.getRecurrenceRules(ComponentPropertyExrule)
+}
+
+func (cb *ComponentBase) getRecurrenceRules(prop ComponentProperty) ([]*RecurrenceRule, error) {
+	props := cb.GetProperties(prop)
+	if len(props) == 0 {
+		return nil, nil
+	}
+	rules := make([]*RecurrenceRule, 0, len(props))
+	for _, p := range props {
+		r, err := ParseRecurrenceRule(p.Value)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", prop, err)
+		}
+		rules = append(rules, r)
+	}
+	return rules, nil
+}
+
+// GetRDates returns all RDATE times, handling both comma-separated values
+// within a single property and multiple RDATE properties.
+func (cb *ComponentBase) GetRDates() ([]time.Time, error) {
+	return cb.getMultiTimeProp(ComponentPropertyRdate)
+}
+
+// GetExDates returns all EXDATE times, handling both comma-separated values
+// within a single property and multiple EXDATE properties.
+func (cb *ComponentBase) GetExDates() ([]time.Time, error) {
+	return cb.getMultiTimeProp(ComponentPropertyExdate)
+}
+
+// GetRecurrenceID returns the RECURRENCE-ID property as a time.Time.
+func (cb *ComponentBase) GetRecurrenceID() (time.Time, error) {
+	return cb.getTimeProp(ComponentPropertyRecurrenceId, false)
+}
+
+func (cb *ComponentBase) getMultiTimeProp(prop ComponentProperty) ([]time.Time, error) {
+	props := cb.GetProperties(prop)
+	if len(props) == 0 {
+		return nil, nil
+	}
+	var times []time.Time
+	for _, p := range props {
+		values := strings.Split(p.Value, ",")
+		// Check if VALUE=DATE is explicitly set in parameters
+		isDateOnly := false
+		if vals, ok := p.ICalParameters["VALUE"]; ok {
+			for _, val := range vals {
+				if val == "DATE" {
+					isDateOnly = true
+					break
+				}
+			}
+		}
+		for _, v := range values {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				continue
+			}
+			t, err := parseTimeValue(v, p.ICalParameters, isDateOnly)
+			if err != nil {
+				return nil, fmt.Errorf("parsing %s value %q: %w", prop, v, err)
+			}
+			times = append(times, t)
+		}
+	}
+	return times, nil
 }
 
 func (cb *ComponentBase) SetSummary(s string, params ...PropertyParameter) {

--- a/recurrence.go
+++ b/recurrence.go
@@ -1,0 +1,337 @@
+package ics
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Frequency string
+
+const (
+	FrequencySecondly Frequency = "SECONDLY"
+	FrequencyMinutely Frequency = "MINUTELY"
+	FrequencyHourly   Frequency = "HOURLY"
+	FrequencyDaily    Frequency = "DAILY"
+	FrequencyWeekly   Frequency = "WEEKLY"
+	FrequencyMonthly  Frequency = "MONTHLY"
+	FrequencyYearly   Frequency = "YEARLY"
+)
+
+type Weekday string
+
+const (
+	WeekdaySunday    Weekday = "SU"
+	WeekdayMonday    Weekday = "MO"
+	WeekdayTuesday   Weekday = "TU"
+	WeekdayWednesday Weekday = "WE"
+	WeekdayThursday  Weekday = "TH"
+	WeekdayFriday    Weekday = "FR"
+	WeekdaySaturday  Weekday = "SA"
+)
+
+type rruleKey string
+
+const (
+	rruleKeyFreq       rruleKey = "FREQ"
+	rruleKeyUntil      rruleKey = "UNTIL"
+	rruleKeyCount      rruleKey = "COUNT"
+	rruleKeyInterval   rruleKey = "INTERVAL"
+	rruleKeyBySecond   rruleKey = "BYSECOND"
+	rruleKeyByMinute   rruleKey = "BYMINUTE"
+	rruleKeyByHour     rruleKey = "BYHOUR"
+	rruleKeyByDay      rruleKey = "BYDAY"
+	rruleKeyByMonthDay rruleKey = "BYMONTHDAY"
+	rruleKeyByYearDay  rruleKey = "BYYEARDAY"
+	rruleKeyByWeekNo   rruleKey = "BYWEEKNO"
+	rruleKeyByMonth    rruleKey = "BYMONTH"
+	rruleKeyBySetPos   rruleKey = "BYSETPOS"
+	rruleKeyWkst       rruleKey = "WKST"
+)
+
+var validWeekdays = map[Weekday]bool{
+	WeekdaySunday: true, WeekdayMonday: true, WeekdayTuesday: true,
+	WeekdayWednesday: true, WeekdayThursday: true, WeekdayFriday: true,
+	WeekdaySaturday: true,
+}
+
+// WeekdayNum represents a weekday with an optional ordinal (e.g., -1SU = last Sunday, 2MO = second Monday).
+// OrdWeek of 0 means no ordinal was specified.
+type WeekdayNum struct {
+	OrdWeek int
+	Day     Weekday
+}
+
+func (wdn WeekdayNum) String() string {
+	if wdn.OrdWeek == 0 {
+		return string(wdn.Day)
+	}
+	return fmt.Sprintf("%d%s", wdn.OrdWeek, wdn.Day)
+}
+
+// RecurrenceRule represents a parsed RRULE as defined in RFC 5545 Section 3.3.10.
+type RecurrenceRule struct {
+	Freq          Frequency
+	Until         time.Time // zero value if unset
+	UntilDateOnly bool      // true when UNTIL was parsed from a date-only value (no time component)
+	Count         int       // 0 if unset
+	Interval      int       // defaults to 1
+	BySecond      []int
+	ByMinute      []int
+	ByHour        []int
+	ByDay         []WeekdayNum
+	ByMonthDay    []int
+	ByYearDay     []int
+	ByWeekNo      []int
+	ByMonth       []int
+	BySetPos      []int
+	Wkst          Weekday // empty string if unset
+}
+
+// ParseRecurrenceRule parses an RRULE value string (without the "RRULE:" prefix)
+// into a RecurrenceRule struct.
+func ParseRecurrenceRule(s string) (*RecurrenceRule, error) {
+	rule := &RecurrenceRule{
+		Interval: 1,
+	}
+
+	parts := strings.Split(s, ";")
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		kv := strings.SplitN(part, "=", 2)
+		if len(kv) != 2 {
+			return nil, fmt.Errorf("invalid RRULE part: %q", part)
+		}
+		key, value := kv[0], kv[1]
+
+		var err error
+		switch rruleKey(key) {
+		case rruleKeyFreq:
+			rule.Freq = Frequency(value)
+			if !isValidFrequency(rule.Freq) {
+				return nil, fmt.Errorf("invalid FREQ value: %q", value)
+			}
+		case rruleKeyUntil:
+			rule.Until, rule.UntilDateOnly, err = parseRecurrenceTime(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid UNTIL value: %w", err)
+			}
+		case rruleKeyCount:
+			rule.Count, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid COUNT value: %w", err)
+			}
+		case rruleKeyInterval:
+			rule.Interval, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid INTERVAL value: %w", err)
+			}
+		case rruleKeyBySecond:
+			rule.BySecond, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYSECOND value: %w", err)
+			}
+		case rruleKeyByMinute:
+			rule.ByMinute, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYMINUTE value: %w", err)
+			}
+		case rruleKeyByHour:
+			rule.ByHour, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYHOUR value: %w", err)
+			}
+		case rruleKeyByDay:
+			rule.ByDay, err = parseWeekdayNumList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYDAY value: %w", err)
+			}
+		case rruleKeyByMonthDay:
+			rule.ByMonthDay, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYMONTHDAY value: %w", err)
+			}
+		case rruleKeyByYearDay:
+			rule.ByYearDay, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYYEARDAY value: %w", err)
+			}
+		case rruleKeyByWeekNo:
+			rule.ByWeekNo, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYWEEKNO value: %w", err)
+			}
+		case rruleKeyByMonth:
+			rule.ByMonth, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYMONTH value: %w", err)
+			}
+		case rruleKeyBySetPos:
+			rule.BySetPos, err = parseIntList(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid BYSETPOS value: %w", err)
+			}
+		case rruleKeyWkst:
+			rule.Wkst = Weekday(value)
+			if !validWeekdays[rule.Wkst] {
+				return nil, fmt.Errorf("invalid WKST value: %q", value)
+			}
+		default:
+			// RFC 5545 says implementations SHOULD ignore unrecognized properties.
+			// This handles vendor extensions (X-...) and future RFC additions.
+		}
+	}
+
+	if rule.Freq == "" {
+		return nil, fmt.Errorf("RRULE missing required FREQ")
+	}
+
+	return rule, nil
+}
+
+// String serializes the RecurrenceRule back to RRULE value format (without "RRULE:" prefix).
+func (r *RecurrenceRule) String() string {
+	var parts []string
+
+	parts = append(parts, "FREQ="+string(r.Freq))
+
+	if !r.Until.IsZero() {
+		if r.UntilDateOnly {
+			parts = append(parts, "UNTIL="+r.Until.Format(icalDateFormatLocal))
+		} else {
+			parts = append(parts, "UNTIL="+r.Until.Format(icalTimestampFormatUtc))
+		}
+	}
+	if r.Count != 0 {
+		parts = append(parts, "COUNT="+strconv.Itoa(r.Count))
+	}
+	if r.Interval != 0 && r.Interval != 1 {
+		parts = append(parts, "INTERVAL="+strconv.Itoa(r.Interval))
+	}
+	if len(r.BySecond) > 0 {
+		parts = append(parts, "BYSECOND="+intListString(r.BySecond))
+	}
+	if len(r.ByMinute) > 0 {
+		parts = append(parts, "BYMINUTE="+intListString(r.ByMinute))
+	}
+	if len(r.ByHour) > 0 {
+		parts = append(parts, "BYHOUR="+intListString(r.ByHour))
+	}
+	if len(r.ByDay) > 0 {
+		strs := make([]string, len(r.ByDay))
+		for i, wd := range r.ByDay {
+			strs[i] = wd.String()
+		}
+		parts = append(parts, "BYDAY="+strings.Join(strs, ","))
+	}
+	if len(r.ByMonthDay) > 0 {
+		parts = append(parts, "BYMONTHDAY="+intListString(r.ByMonthDay))
+	}
+	if len(r.ByYearDay) > 0 {
+		parts = append(parts, "BYYEARDAY="+intListString(r.ByYearDay))
+	}
+	if len(r.ByWeekNo) > 0 {
+		parts = append(parts, "BYWEEKNO="+intListString(r.ByWeekNo))
+	}
+	if len(r.ByMonth) > 0 {
+		parts = append(parts, "BYMONTH="+intListString(r.ByMonth))
+	}
+	if len(r.BySetPos) > 0 {
+		parts = append(parts, "BYSETPOS="+intListString(r.BySetPos))
+	}
+	if r.Wkst != "" {
+		parts = append(parts, "WKST="+string(r.Wkst))
+	}
+
+	return strings.Join(parts, ";")
+}
+
+func isValidFrequency(f Frequency) bool {
+	switch f {
+	case FrequencySecondly, FrequencyMinutely, FrequencyHourly,
+		FrequencyDaily, FrequencyWeekly, FrequencyMonthly, FrequencyYearly:
+		return true
+	}
+	return false
+}
+
+func parseRecurrenceTime(s string) (time.Time, bool, error) {
+	// Try datetime with UTC (20060102T150405Z)
+	if t, err := time.Parse(icalTimestampFormatUtc, s); err == nil {
+		return t, false, nil
+	}
+	// Try date only with UTC (20060102Z)
+	if t, err := time.Parse(icalDateFormatUtc, s); err == nil {
+		return t, true, nil
+	}
+	// Try date only without timezone (20060102)
+	if t, err := time.Parse(icalDateFormatLocal, s); err == nil {
+		return t, true, nil
+	}
+	// Try datetime without UTC (20060102T150405)
+	if t, err := time.Parse(icalTimestampFormatLocal, s); err == nil {
+		return t, false, nil
+	}
+	return time.Time{}, false, fmt.Errorf("cannot parse time %q", s)
+}
+
+func parseIntList(s string) ([]int, error) {
+	parts := strings.Split(s, ",")
+	result := make([]int, 0, len(parts))
+	for _, p := range parts {
+		n, err := strconv.Atoi(strings.TrimSpace(p))
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, n)
+	}
+	return result, nil
+}
+
+func parseWeekdayNumList(s string) ([]WeekdayNum, error) {
+	parts := strings.Split(s, ",")
+	result := make([]WeekdayNum, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		wdn, err := parseWeekdayNum(p)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, wdn)
+	}
+	return result, nil
+}
+
+func parseWeekdayNum(s string) (WeekdayNum, error) {
+	if len(s) < 2 {
+		return WeekdayNum{}, fmt.Errorf("invalid BYDAY value: %q", s)
+	}
+
+	day := Weekday(s[len(s)-2:])
+	if !validWeekdays[day] {
+		return WeekdayNum{}, fmt.Errorf("invalid weekday: %q", s)
+	}
+
+	ordStr := s[:len(s)-2]
+	if ordStr == "" {
+		return WeekdayNum{Day: day}, nil
+	}
+
+	ord, err := strconv.Atoi(ordStr)
+	if err != nil {
+		return WeekdayNum{}, fmt.Errorf("invalid ordinal in BYDAY value %q: %w", s, err)
+	}
+
+	return WeekdayNum{OrdWeek: ord, Day: day}, nil
+}
+
+func intListString(nums []int) string {
+	strs := make([]string, len(nums))
+	for i, n := range nums {
+		strs[i] = strconv.Itoa(n)
+	}
+	return strings.Join(strs, ",")
+}

--- a/recurrence_test.go
+++ b/recurrence_test.go
@@ -1,0 +1,412 @@
+package ics
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRecurrenceRule(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *RecurrenceRule
+		wantErr bool
+	}{
+		{
+			name:  "simple daily with count",
+			input: "FREQ=DAILY;COUNT=10",
+			want: &RecurrenceRule{
+				Freq:     FrequencyDaily,
+				Count:    10,
+				Interval: 1,
+			},
+		},
+		{
+			name:  "yearly with BYMONTH and BYDAY",
+			input: "FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+			want: &RecurrenceRule{
+				Freq:     FrequencyYearly,
+				Interval: 1,
+				ByMonth:  []int{10},
+				ByDay:    []WeekdayNum{{OrdWeek: -1, Day: WeekdaySunday}},
+			},
+		},
+		{
+			name:  "weekly with interval and multiple days",
+			input: "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+			want: &RecurrenceRule{
+				Freq:     FrequencyWeekly,
+				Interval: 2,
+				ByDay: []WeekdayNum{
+					{Day: WeekdayMonday},
+					{Day: WeekdayWednesday},
+					{Day: WeekdayFriday},
+				},
+			},
+		},
+		{
+			name:  "monthly with BYMONTHDAY",
+			input: "FREQ=MONTHLY;BYMONTHDAY=15",
+			want: &RecurrenceRule{
+				Freq:       FrequencyMonthly,
+				Interval:   1,
+				ByMonthDay: []int{15},
+			},
+		},
+		{
+			name:  "monthly with ordinal BYDAY",
+			input: "FREQ=MONTHLY;BYDAY=2MO",
+			want: &RecurrenceRule{
+				Freq:     FrequencyMonthly,
+				Interval: 1,
+				ByDay:    []WeekdayNum{{OrdWeek: 2, Day: WeekdayMonday}},
+			},
+		},
+		{
+			name:  "yearly with UNTIL (datetime)",
+			input: "FREQ=YEARLY;UNTIL=20251231T235959Z",
+			want: &RecurrenceRule{
+				Freq:     FrequencyYearly,
+				Interval: 1,
+				Until:    time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC),
+			},
+		},
+		{
+			name:  "yearly with UNTIL (date only)",
+			input: "FREQ=YEARLY;UNTIL=20251231",
+			want: &RecurrenceRule{
+				Freq:          FrequencyYearly,
+				Interval:      1,
+				Until:         time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC),
+				UntilDateOnly: true,
+			},
+		},
+		{
+			name:  "with WKST",
+			input: "FREQ=WEEKLY;WKST=SU",
+			want: &RecurrenceRule{
+				Freq:     FrequencyWeekly,
+				Interval: 1,
+				Wkst:     WeekdaySunday,
+			},
+		},
+		{
+			name:  "complex with multiple BY rules",
+			input: "FREQ=YEARLY;BYMONTH=3;BYDAY=SU;BYHOUR=2;BYMINUTE=0;BYSECOND=0",
+			want: &RecurrenceRule{
+				Freq:     FrequencyYearly,
+				Interval: 1,
+				ByMonth:  []int{3},
+				ByDay:    []WeekdayNum{{Day: WeekdaySunday}},
+				ByHour:   []int{2},
+				ByMinute: []int{0},
+				BySecond: []int{0},
+			},
+		},
+		{
+			name:  "with BYSETPOS",
+			input: "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1",
+			want: &RecurrenceRule{
+				Freq:     FrequencyMonthly,
+				Interval: 1,
+				ByDay: []WeekdayNum{
+					{Day: WeekdayMonday}, {Day: WeekdayTuesday}, {Day: WeekdayWednesday},
+					{Day: WeekdayThursday}, {Day: WeekdayFriday},
+				},
+				BySetPos: []int{-1},
+			},
+		},
+		{
+			name:  "with BYYEARDAY and BYWEEKNO",
+			input: "FREQ=YEARLY;BYYEARDAY=1,100,200;BYWEEKNO=20",
+			want: &RecurrenceRule{
+				Freq:      FrequencyYearly,
+				Interval:  1,
+				ByYearDay: []int{1, 100, 200},
+				ByWeekNo:  []int{20},
+			},
+		},
+		{
+			name:    "missing FREQ",
+			input:   "COUNT=10",
+			wantErr: true,
+		},
+		{
+			name:    "invalid FREQ",
+			input:   "FREQ=BIWEEKLY",
+			wantErr: true,
+		},
+		{
+			name:    "invalid BYDAY",
+			input:   "FREQ=WEEKLY;BYDAY=XX",
+			wantErr: true,
+		},
+		{
+			name:    "invalid COUNT",
+			input:   "FREQ=DAILY;COUNT=abc",
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:  "unknown keys are ignored per RFC 5545",
+			input: "FREQ=DAILY;X-CUSTOM=foo;COUNT=5",
+			want: &RecurrenceRule{
+				Freq:     FrequencyDaily,
+				Count:    5,
+				Interval: 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseRecurrenceRule(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want.Freq, got.Freq)
+			assert.Equal(t, tt.want.Count, got.Count)
+			assert.Equal(t, tt.want.Interval, got.Interval)
+			assert.Equal(t, tt.want.ByMonth, got.ByMonth)
+			assert.Equal(t, tt.want.ByDay, got.ByDay)
+			assert.Equal(t, tt.want.ByMonthDay, got.ByMonthDay)
+			assert.Equal(t, tt.want.ByYearDay, got.ByYearDay)
+			assert.Equal(t, tt.want.ByWeekNo, got.ByWeekNo)
+			assert.Equal(t, tt.want.ByHour, got.ByHour)
+			assert.Equal(t, tt.want.ByMinute, got.ByMinute)
+			assert.Equal(t, tt.want.BySecond, got.BySecond)
+			assert.Equal(t, tt.want.BySetPos, got.BySetPos)
+			assert.Equal(t, tt.want.Wkst, got.Wkst)
+			if !tt.want.Until.IsZero() {
+				assert.True(t, tt.want.Until.Equal(got.Until), "Until: want %v, got %v", tt.want.Until, got.Until)
+				assert.Equal(t, tt.want.UntilDateOnly, got.UntilDateOnly)
+			}
+		})
+	}
+}
+
+func TestRecurrenceRuleString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "simple daily",
+			input: "FREQ=DAILY;COUNT=10",
+			want:  "FREQ=DAILY;COUNT=10",
+		},
+		{
+			name:  "yearly with BYMONTH and BYDAY",
+			input: "FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU",
+			want:  "FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10",
+		},
+		{
+			name:  "weekly with interval",
+			input: "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+			want:  "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR",
+		},
+		{
+			name:  "with UNTIL datetime",
+			input: "FREQ=YEARLY;UNTIL=20251231T235959Z",
+			want:  "FREQ=YEARLY;UNTIL=20251231T235959Z",
+		},
+		{
+			name:  "with UNTIL date only",
+			input: "FREQ=YEARLY;UNTIL=20251231",
+			want:  "FREQ=YEARLY;UNTIL=20251231",
+		},
+		{
+			name:  "with WKST",
+			input: "FREQ=WEEKLY;WKST=SU",
+			want:  "FREQ=WEEKLY;WKST=SU",
+		},
+		{
+			name:  "midnight UTC UNTIL round-trips as datetime not date-only",
+			input: "FREQ=YEARLY;UNTIL=20251231T000000Z",
+			want:  "FREQ=YEARLY;UNTIL=20251231T000000Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule, err := ParseRecurrenceRule(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, rule.String())
+		})
+	}
+}
+
+func TestGetRRules(t *testing.T) {
+	event := NewEvent("test-rrule")
+	event.AddRrule("FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU")
+
+	rules, err := event.GetRRules()
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, FrequencyYearly, rules[0].Freq)
+	assert.Equal(t, []int{10}, rules[0].ByMonth)
+	assert.Equal(t, []WeekdayNum{{OrdWeek: -1, Day: WeekdaySunday}}, rules[0].ByDay)
+}
+
+func TestGetRRulesMultiple(t *testing.T) {
+	event := NewEvent("test-rrule-multi")
+	event.AddRrule("FREQ=DAILY;COUNT=5")
+	event.AddRrule("FREQ=WEEKLY;BYDAY=MO")
+
+	rules, err := event.GetRRules()
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	assert.Equal(t, FrequencyDaily, rules[0].Freq)
+	assert.Equal(t, FrequencyWeekly, rules[1].Freq)
+}
+
+func TestGetRRulesEmpty(t *testing.T) {
+	event := NewEvent("test-no-rrule")
+	rules, err := event.GetRRules()
+	require.NoError(t, err)
+	assert.Nil(t, rules)
+}
+
+func TestGetExRules(t *testing.T) {
+	event := NewEvent("test-exrule")
+	event.AddExrule("FREQ=YEARLY;BYMONTH=12;BYMONTHDAY=25")
+
+	rules, err := event.GetExRules()
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, FrequencyYearly, rules[0].Freq)
+}
+
+func TestGetExDates(t *testing.T) {
+	event := NewEvent("test-exdate")
+	event.AddExdate("20231225T120000Z")
+
+	dates, err := event.GetExDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 1)
+	assert.True(t, dates[0].Equal(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC)))
+}
+
+func TestGetExDatesCommaSeparated(t *testing.T) {
+	event := NewEvent("test-exdate-csv")
+	event.AddExdate("20231225T120000Z,20231226T120000Z")
+
+	dates, err := event.GetExDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 2)
+	assert.True(t, dates[0].Equal(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC)))
+	assert.True(t, dates[1].Equal(time.Date(2023, 12, 26, 12, 0, 0, 0, time.UTC)))
+}
+
+func TestGetExDatesMultipleProperties(t *testing.T) {
+	event := NewEvent("test-exdate-multi")
+	event.AddExdate("20231225T120000Z")
+	event.AddExdate("20231226T120000Z")
+
+	dates, err := event.GetExDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 2)
+}
+
+func TestGetExDatesAllDay(t *testing.T) {
+	event := NewEvent("test-exdate-allday")
+	event.AddExdate("20231225")
+
+	dates, err := event.GetExDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 1)
+	assert.Equal(t, 2023, dates[0].Year())
+	assert.Equal(t, time.December, dates[0].Month())
+	assert.Equal(t, 25, dates[0].Day())
+}
+
+func TestGetExDatesEmpty(t *testing.T) {
+	event := NewEvent("test-no-exdate")
+	dates, err := event.GetExDates()
+	require.NoError(t, err)
+	assert.Nil(t, dates)
+}
+
+func TestGetRDates(t *testing.T) {
+	event := NewEvent("test-rdate")
+	event.AddRdate("20240101T000000Z")
+
+	dates, err := event.GetRDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 1)
+	assert.True(t, dates[0].Equal(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)))
+}
+
+func TestGetRDatesCommaSeparated(t *testing.T) {
+	event := NewEvent("test-rdate-csv")
+	event.AddRdate("20240101T000000Z,20240201T000000Z")
+
+	dates, err := event.GetRDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 2)
+}
+
+func TestGetRecurrenceID(t *testing.T) {
+	ical := `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-recurrence-id
+RECURRENCE-ID:20231225T120000Z
+DTSTART:20231226T120000Z
+DTEND:20231226T130000Z
+SUMMARY:Modified occurrence
+END:VEVENT
+END:VCALENDAR`
+
+	cal, err := ParseCalendar(strings.NewReader(ical))
+	require.NoError(t, err)
+
+	events := cal.Events()
+	require.Len(t, events, 1)
+
+	recID, err := events[0].GetRecurrenceID()
+	require.NoError(t, err)
+	assert.True(t, recID.Equal(time.Date(2023, 12, 25, 12, 0, 0, 0, time.UTC)))
+}
+
+func TestGetRecurrenceIDNotSet(t *testing.T) {
+	event := NewEvent("test-no-recurrence-id")
+	_, err := event.GetRecurrenceID()
+	assert.Error(t, err)
+}
+
+func TestGetExDatesWithTZID(t *testing.T) {
+	ical := `BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:test-exdate-tzid
+DTSTART;TZID=America/New_York:20231201T090000
+EXDATE;TZID=America/New_York:20231208T090000
+SUMMARY:Weekly meeting
+RRULE:FREQ=WEEKLY;COUNT=10
+END:VEVENT
+END:VCALENDAR`
+
+	cal, err := ParseCalendar(strings.NewReader(ical))
+	require.NoError(t, err)
+
+	events := cal.Events()
+	require.Len(t, events, 1)
+
+	dates, err := events[0].GetExDates()
+	require.NoError(t, err)
+	require.Len(t, dates, 1)
+
+	loc, _ := time.LoadLocation("America/New_York")
+	expected := time.Date(2023, 12, 8, 9, 0, 0, 0, loc)
+	assert.True(t, dates[0].Equal(expected), "want %v, got %v", expected, dates[0])
+}


### PR DESCRIPTION
I don't think this library should be doing its own RRULE computation, but it is in the right place to decode it.

This PR adds helpers to get that data out, and examples in the README to use another rrule parser to help expand events out for a particular time range.

It is pretty complicated, but I'm using this currently with a calendar project I have.

Fixes #117