### PR TITLE
feat: add WithPropertyParseErrorHandler ParseOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,49 +1,144 @@
 # golang-ical
-A  ICS / ICal parser and serialiser for Golang.
+
+An ICS / ICal parser and serialiser for Golang.
 
 [![GoDoc](https://godoc.org/github.com/arran4/golang-ical?status.svg)](https://godoc.org/github.com/arran4/golang-ical)
 
 Because the other libraries didn't quite do what I needed.
 
+## Parsing Calendars
+
 Usage, parsing:
 ```golang
-    cal, err := ParseCalendar(strings.NewReader(input))
-
+import (
+    "strings"
+    
+    ics "github.com/arran4/golang-ical"
+)
+cal, err := ics.ParseCalendar(strings.NewReader(input))
 ```
 
 Usage, parsing from a URL:
 ```golang
-    cal, err := ParseCalendarFromUrl("https://your-ics-url")
+cal, err := ics.ParseCalendarFromUrl("https://your-ics-url")
 ```
 
-Creating:
+## Creating Calendars
+
+Usage, creating a calendar:
 ```golang
-  cal := ics.NewCalendar()
-  cal.SetMethod(ics.MethodRequest)
-  event := cal.AddEvent(fmt.Sprintf("id@domain", p.SessionKey.IntID()))
-  event.SetCreatedTime(time.Now())
-  event.SetDtStampTime(time.Now())
-  event.SetModifiedAt(time.Now())
-  event.SetStartAt(time.Now())
-  event.SetEndAt(time.Now())
-  event.SetSummary("Summary")
-  event.SetLocation("Address")
-  event.SetDescription("Description")
-  event.SetURL("https://URL/")
-  event.AddRrule(fmt.Sprintf("FREQ=YEARLY;BYMONTH=%d;BYMONTHDAY=%d", time.Now().Month(), time.Now().Day()))
-  event.SetOrganizer("sender@domain", ics.WithCN("This Machine"))
-  event.AddAttendee("reciever or participant", ics.CalendarUserTypeIndividual, ics.ParticipationStatusNeedsAction, ics.ParticipationRoleReqParticipant, ics.WithRSVP(true))
-  return cal.Serialize()
+cal := ics.NewCalendar()
+cal.SetMethod(ics.MethodRequest)
+event := cal.AddEvent(fmt.Sprintf("id@domain", p.SessionKey.IntID()))
+event.SetCreatedTime(time.Now())
+event.SetDtStampTime(time.Now())
+event.SetModifiedAt(time.Now())
+event.SetStartAt(time.Now())
+event.SetEndAt(time.Now())
+event.SetSummary("Summary")
+event.SetLocation("Address")
+event.SetDescription("Description")
+event.SetURL("https://URL/")
+event.AddRrule(fmt.Sprintf("FREQ=YEARLY;BYMONTH=%d;BYMONTHDAY=%d", time.Now().Month(), time.Now().Day()))
+event.SetOrganizer("sender@domain", ics.WithCN("This Machine"))
+event.AddAttendee("receiver or participant", ics.CalendarUserTypeIndividual, ics.ParticipationStatusNeedsAction, ics.ParticipationRoleReqParticipant, ics.WithRSVP(true))
+return cal.Serialize()
+```
+*Helper methods created as needed feel free to send a P.R. with more.*
+
+You can also construct a calendar with options:
+
+```golang
+cal, err := ics.NewCalendarWithOptions(
+    ics.WithVersion("2.0"),
+    ics.WithProductId("-//my-service//Golang ICS Library"),
+)
 ```
 
-Helper methods created as needed feel free to send a P.R. with more.
+When to use which constructor:
+- Use `NewCalendar()` for the default metadata:
+  - `VERSION:2.0`
+  - `PRODID:-//arran4//Golang ICS Library`
+- Use `NewCalendarFor(service)` when you want the same defaults but a service-specific `PRODID` without building options manually.
+  - It sets `VERSION:2.0`.
+  - It sets `PRODID:-//<service>//Golang ICS Library`.
+  - Example: `ics.NewCalendarFor("my-team")` yields `PRODID:-//my-team//Golang ICS Library`.
+- Use `NewCalendarWithOptions(...)` when you need full control at construction time (for example custom `WithVersion(...)` or custom `WithProductId(...)`).
 
-# Working with Recurring Events
+Use `NewCalendarFor(service)` when you publish ICS from multiple applications/tenants and want each feed to identify its producer via `PRODID` while still using library defaults.
+
+## Parsing malformed properties (strict/skip/recover)
+
+By default, parsing is strict and returns an error for malformed content lines.
+
+```golang
+cal, err := ics.ParseCalendar(reader)
+```
+
+For real-world feeds with malformed properties, use `ParseCalendarWithOptions` and provide a custom property parser.
+
+Pre-built parser helpers are included:
+- `SkipPropertyParser`: ignore malformed lines.
+- `FallbackParser(LooseParser)`: try strict parsing first, then recover by keeping token/value.
+
+Skip malformed properties:
+
+```golang
+cal, err := ics.ParseCalendarWithOptions(reader,
+    ics.WithPropertyParser(ics.SkipPropertyParser),
+)
+```
+
+Recover malformed properties by keeping token + value (dropping malformed params):
+
+```golang
+cal, err := ics.ParseCalendarWithOptions(reader,
+    ics.WithPropertyParser(ics.FallbackParser(ics.LooseParser)),
+)
+```
+
+Custom parser behavior:
+
+```golang
+import (
+    "fmt"
+    "strings"
+
+    ics "github.com/arran4/golang-ical"
+)
+
+parser := func(rawLine ics.ContentLine) (*ics.BaseProperty, error) {
+    // Try strict parsing first.
+    line, err := ics.ParseProperty(rawLine)
+    if err == nil {
+        return line, nil
+    }
+
+    // Skip specific lines and continue.
+    if strings.Contains(string(rawLine), "X-TKF-") {
+        return nil, fmt.Errorf("%w: skipping Tockify extension", ics.ErrPropertySkipped)
+    }
+
+    // Abort for everything else.
+    return nil, err
+}
+
+cal, err := ics.ParseCalendarWithOptions(reader, parser)
+```
+
+Notes:
+- `ErrPropertySkipped` means "ignore this line and continue".
+- Returning `(nil, nil)` from a parser also skips the line.
+- `WithPropertyParser(...)` and passing a parser directly to `ParseCalendarWithOptions(...)` are equivalent.
+- The same parser is used for nested components (for example, malformed properties inside `VALARM`).
+- Invalid option types return an error wrapped with `ErrInvalidOpArg`.
+
+## Working with Recurring Events
 
 This library parses and provides typed access to recurrence properties (`RRULE`, `RDATE`, `EXDATE`, `EXRULE`, `RECURRENCE-ID`) but does not expand them into concrete occurrence dates.
 This keeps the library dependency-free and lets callers choose their own expansion strategy.
 
-## Accessing recurrence properties
+### Accessing recurrence properties
 
 ```golang
   // Parse RRULE into a structured type
@@ -68,13 +163,13 @@ This keeps the library dependency-free and lets callers choose their own expansi
   fmt.Println(rule.String()) // "FREQ=WEEKLY;INTERVAL=2;BYDAY=MO,WE,FR"
 ```
 
-## Expanding occurrences with rrule-go
+### Expanding occurrences with rrule-go
 
 To expand recurring events into concrete dates, use a library like [rrule-go](https://github.com/teambition/rrule-go):
 
 ```golang
   import (
-      "github.com/arran4/golang-ical"
+      ics "github.com/arran4/golang-ical"
       "github.com/teambition/rrule-go"
   )
 
@@ -146,6 +241,6 @@ These appear as separate VEVENTs with the same UID but a `RECURRENCE-ID` propert
   // override represents a cancellation).
 ```
 
-# Notice
+## Notice
 
 Looking for a co-maintainer.

--- a/calendar.go
+++ b/calendar.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"reflect"
 	"strings"
 	"time"
 )
@@ -471,7 +470,7 @@ func parseSerializeOps(ops []any) (*SerializationConfiguration, error) {
 		case error:
 			return nil, op
 		default:
-			return nil, fmt.Errorf("unknown op %d of type %s", opi, reflect.TypeOf(op))
+			return nil, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, opi, op)
 		}
 	}
 	return serializeConfig, nil
@@ -647,7 +646,7 @@ func ParseCalendarFromUrl(url string, opts ...any) (*Calendar, error) {
 		case func() context.Context:
 			ctx = opt()
 		default:
-			return nil, fmt.Errorf("unknown optional argument %d on ParseCalendarFromUrl: %s", opti, reflect.TypeOf(opt))
+			return nil, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, opti, opt)
 		}
 	}
 	if ctx == nil {
@@ -762,7 +761,7 @@ func NewCalendarWithOptions(options ...any) (*Calendar, error) {
 				c.propertyParser = PropertyParser(opt)
 			}
 		default:
-			return nil, fmt.Errorf("invalid parse option type at index %d: %T", i, opt)
+			return nil, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
 		}
 	}
 	return c, nil

--- a/calendar.go
+++ b/calendar.go
@@ -746,21 +746,12 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 		if l == nil || len(*l) == 0 {
 			continue
 		}
-		line, err := ParseProperty(*l)
+		line, skip, err := parseProperty(*l, c.propertyParseErrorHandler)
 		if err != nil {
-			if c.propertyParseErrorHandler != nil {
-				var recovered *BaseProperty
-				recovered, err = c.propertyParseErrorHandler(*l, err)
-				if err != nil {
-					return nil, fmt.Errorf("parsing line %d: %w", ln, err)
-				}
-				if recovered == nil {
-					continue // skip this line
-				}
-				line = recovered
-			} else {
-				return nil, fmt.Errorf("parsing line %d: %w", ln, err)
-			}
+			return nil, fmt.Errorf("parsing line %d: %w", ln, err)
+		}
+		if skip {
+			continue
 		}
 		if line == nil {
 			return nil, fmt.Errorf("parsing calendar line %d", ln)

--- a/calendar.go
+++ b/calendar.go
@@ -401,6 +401,7 @@ type Calendar struct {
 	Components                     []Component
 	CalendarProperties             []CalendarProperty
 	unknownCalendarPropertyHandler func(cal *Calendar, state string, cl *BaseProperty) error
+	propertyParseErrorHandler      func(rawLine ContentLine, err error) (*BaseProperty, error)
 }
 
 func NewCalendar() *Calendar {
@@ -691,6 +692,25 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 	}
 }
 
+// WithPropertyParseErrorHandler allows custom handling of property parse errors.
+// When a content line fails to parse (e.g. due to malformed parameter names),
+// the handler is called with the raw content line and the parse error.
+//
+// The handler can:
+//   - Return (*BaseProperty, nil) to use a recovered/replacement property
+//   - Return (nil, nil) to skip the property silently
+//   - Return (nil, err) to abort parsing with the error
+//
+// Without this option, any property parse error aborts the entire calendar parse.
+// This is useful for real-world ICS feeds that contain non-RFC-compliant properties
+// (e.g. parameter names with underscores).
+func WithPropertyParseErrorHandler(f func(rawLine ContentLine, err error) (*BaseProperty, error)) ParseOption {
+	return func(c *Calendar) error {
+		c.propertyParseErrorHandler = f
+		return nil
+	}
+}
+
 func ParseCalendar(r io.Reader) (*Calendar, error) {
 	// Default behavior maintains backward compatibility (strict mode)
 	return ParseCalendarWithOptions(r)
@@ -728,7 +748,19 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 		}
 		line, err := ParseProperty(*l)
 		if err != nil {
-			return nil, fmt.Errorf("parsing line %d: %w", ln, err)
+			if c.propertyParseErrorHandler != nil {
+				var recovered *BaseProperty
+				recovered, err = c.propertyParseErrorHandler(*l, err)
+				if err != nil {
+					return nil, fmt.Errorf("parsing line %d: %w", ln, err)
+				}
+				if recovered == nil {
+					continue // skip this line
+				}
+				line = recovered
+			} else {
+				return nil, fmt.Errorf("parsing line %d: %w", ln, err)
+			}
 		}
 		if line == nil {
 			return nil, fmt.Errorf("parsing calendar line %d", ln)
@@ -774,7 +806,7 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 					return nil, errors.New("malformed calendar; expected end")
 				}
 			case "BEGIN":
-				co, err := GeneralParseComponent(cs, line)
+				co, err := generalParseComponentWithHandler(cs, line, c.propertyParseErrorHandler)
 				if err != nil {
 					return nil, err
 				}

--- a/calendar.go
+++ b/calendar.go
@@ -405,16 +405,18 @@ type Calendar struct {
 }
 
 func NewCalendar() *Calendar {
-	return NewCalendarFor("arran4")
+	c, _ := NewCalendarWithOptions(
+		WithVersion("2.0"),
+		WithProductId("-//arran4//Golang ICS Library"),
+	)
+	return c
 }
 
 func NewCalendarFor(service string) *Calendar {
-	c := &Calendar{
-		Components:         []Component{},
-		CalendarProperties: []CalendarProperty{},
-	}
-	c.SetVersion("2.0")
-	c.SetProductId("-//" + service + "//Golang ICS Library")
+	c, _ := NewCalendarWithOptions(
+		WithVersion("2.0"),
+		WithProductId("-//"+service+"//Golang ICS Library"),
+	)
 	return c
 }
 
@@ -684,6 +686,25 @@ func parseCalendarFromHttpRequest(client HttpClientLike, request *http.Request) 
 // ParseOption provides functional options for ParseCalendar
 type ParseOption func(*Calendar) error
 
+// CalendarOption provides functional options for Calendar construction.
+type CalendarOption func(*Calendar) error
+
+// WithVersion sets the calendar version.
+func WithVersion(version string, params ...PropertyParameter) CalendarOption {
+	return func(c *Calendar) error {
+		c.SetVersion(version, params...)
+		return nil
+	}
+}
+
+// WithProductId sets the calendar product identifier.
+func WithProductId(productID string, params ...PropertyParameter) CalendarOption {
+	return func(c *Calendar) error {
+		c.SetProductId(productID, params...)
+		return nil
+	}
+}
+
 // WithUnknownPropertyHandler allows custom handling of unknown properties
 func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) ParseOption {
 	return func(c *Calendar) error {
@@ -712,6 +733,37 @@ func WithPropertyParser(f PropertyParser) ParseOption {
 	}
 }
 
+// NewCalendarWithOptions constructs a calendar with sane parser defaults and optional overrides.
+func NewCalendarWithOptions(options ...any) (*Calendar, error) {
+	c := &Calendar{
+		Components:                     []Component{},
+		CalendarProperties:             []CalendarProperty{},
+		unknownCalendarPropertyHandler: DefaultUnknownCalendarPropertyHandler,
+		propertyParser:                 parseProperty,
+	}
+	for _, opt := range options {
+		switch opt := opt.(type) {
+		case CalendarOption:
+			if err := opt(c); err != nil {
+				return nil, err
+			}
+		case ParseOption:
+			if err := opt(c); err != nil {
+				return nil, err
+			}
+		case PropertyParser:
+			if opt != nil {
+				c.propertyParser = opt
+			}
+		case func(ContentLine) (*BaseProperty, error):
+			if opt != nil {
+				c.propertyParser = PropertyParser(opt)
+			}
+		}
+	}
+	return c, nil
+}
+
 func ParseCalendar(r io.Reader) (*Calendar, error) {
 	// Default behavior maintains backward compatibility (strict mode)
 	return ParseCalendarWithOptions(r)
@@ -719,28 +771,11 @@ func ParseCalendar(r io.Reader) (*Calendar, error) {
 
 func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 	state := "begin"
-	c := &Calendar{
-		unknownCalendarPropertyHandler: DefaultUnknownCalendarPropertyHandler,
-	}
-	for _, opt := range options {
-		switch opt := opt.(type) {
-		case ParseOption:
-			if err := opt(c); err != nil {
-				return nil, fmt.Errorf("invalid parse option: %w", err)
-			}
-		case PropertyParser:
-			c.propertyParser = opt
-		case func(ContentLine) (*BaseProperty, error):
-			c.propertyParser = PropertyParser(opt)
-		default:
-			return nil, fmt.Errorf("invalid parse option type: %T", opt)
-		}
+	c, err := NewCalendarWithOptions(options...)
+	if err != nil {
+		return nil, err
 	}
 	cs := NewCalendarStream(r)
-	parser := parseProperty
-	if c.propertyParser != nil {
-		parser = c.propertyParser
-	}
 	cont := true
 	for ln := 0; cont; ln++ {
 		l, err := cs.ReadLine()
@@ -755,8 +790,11 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 		if l == nil || len(*l) == 0 {
 			continue
 		}
-		line, err := parser(*l)
+		line, err := c.propertyParser(*l)
 		if err != nil {
+			if errors.Is(err, ErrPropertySkipped) {
+				continue
+			}
 			return nil, fmt.Errorf("parsing line %d: %w", ln, err)
 		}
 		if line == nil {

--- a/calendar.go
+++ b/calendar.go
@@ -401,7 +401,7 @@ type Calendar struct {
 	Components                     []Component
 	CalendarProperties             []CalendarProperty
 	unknownCalendarPropertyHandler func(cal *Calendar, state string, cl *BaseProperty) error
-	propertyParseErrorHandler      PropertyParseErrorHandler
+	propertyParser                 PropertyParser
 }
 
 func NewCalendar() *Calendar {
@@ -692,11 +692,12 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 	}
 }
 
-// WithPropertyParseErrorHandler allows custom handling of property parse errors.
+// WithPropertyParser allows custom handling of property parse errors.
+// It is a convenience wrapper; ParseCalendarWithOptions also accepts PropertyParser directly.
 // When a content line fails to parse (e.g. due to malformed parameter names),
-// the handler is called with the raw content line and the parse error.
+// the parser is called with the raw content line and the parse error.
 //
-// The handler can:
+// The parser can:
 //   - Return (*BaseProperty, nil) to use a recovered/replacement property
 //   - Return (nil, nil) to skip the property silently
 //   - Return (nil, err) to abort parsing with the error
@@ -704,9 +705,9 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 // Without this option, any property parse error aborts the entire calendar parse.
 // This is useful for real-world ICS feeds that contain non-RFC-compliant properties
 // (e.g. parameter names with underscores).
-func WithPropertyParseErrorHandler(f PropertyParseErrorHandler) ParseOption {
+func WithPropertyParser(f PropertyParser) ParseOption {
 	return func(c *Calendar) error {
-		c.propertyParseErrorHandler = f
+		c.propertyParser = f
 		return nil
 	}
 }
@@ -727,11 +728,19 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 			if err := opt(c); err != nil {
 				return nil, fmt.Errorf("invalid parse option: %w", err)
 			}
+		case PropertyParser:
+			c.propertyParser = opt
+		case func(ContentLine) (*BaseProperty, error):
+			c.propertyParser = PropertyParser(opt)
 		default:
 			return nil, fmt.Errorf("invalid parse option type: %T", opt)
 		}
 	}
 	cs := NewCalendarStream(r)
+	parser := parseProperty
+	if c.propertyParser != nil {
+		parser = c.propertyParser
+	}
 	cont := true
 	for ln := 0; cont; ln++ {
 		l, err := cs.ReadLine()
@@ -746,15 +755,12 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 		if l == nil || len(*l) == 0 {
 			continue
 		}
-		line, skip, err := parseProperty(*l, c.propertyParseErrorHandler)
+		line, err := parser(*l)
 		if err != nil {
 			return nil, fmt.Errorf("parsing line %d: %w", ln, err)
 		}
-		if skip {
-			continue
-		}
 		if line == nil {
-			return nil, fmt.Errorf("parsing calendar line %d", ln)
+			continue
 		}
 		switch state {
 		case "begin":
@@ -797,7 +803,7 @@ func ParseCalendarWithOptions(r io.Reader, options ...any) (*Calendar, error) {
 					return nil, errors.New("malformed calendar; expected end")
 				}
 			case "BEGIN":
-				co, err := generalParseComponentWithHandler(cs, line, c.propertyParseErrorHandler)
+				co, err := generalParseComponentWithHandler(cs, line, c.propertyParser)
 				if err != nil {
 					return nil, err
 				}

--- a/calendar.go
+++ b/calendar.go
@@ -728,7 +728,9 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 // (e.g. parameter names with underscores).
 func WithPropertyParser(f PropertyParser) ParseOption {
 	return func(c *Calendar) error {
-		c.propertyParser = f
+		if f != nil {
+			c.propertyParser = f
+		}
 		return nil
 	}
 }

--- a/calendar.go
+++ b/calendar.go
@@ -716,7 +716,7 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 // WithPropertyParser allows custom handling of property parse errors.
 // It is a convenience wrapper; ParseCalendarWithOptions also accepts PropertyParser directly.
 // When a content line fails to parse (e.g. due to malformed parameter names),
-// the parser is called with the raw content line and the parse error.
+// the parser is called with the raw content line.
 //
 // The parser can:
 //   - Return (*BaseProperty, nil) to use a recovered/replacement property
@@ -741,7 +741,7 @@ func NewCalendarWithOptions(options ...any) (*Calendar, error) {
 		unknownCalendarPropertyHandler: DefaultUnknownCalendarPropertyHandler,
 		propertyParser:                 parseProperty,
 	}
-	for _, opt := range options {
+	for i, opt := range options {
 		switch opt := opt.(type) {
 		case CalendarOption:
 			if err := opt(c); err != nil {
@@ -759,6 +759,8 @@ func NewCalendarWithOptions(options ...any) (*Calendar, error) {
 			if opt != nil {
 				c.propertyParser = PropertyParser(opt)
 			}
+		default:
+			return nil, fmt.Errorf("invalid parse option type at index %d: %T", i, opt)
 		}
 	}
 	return c, nil

--- a/calendar.go
+++ b/calendar.go
@@ -401,7 +401,7 @@ type Calendar struct {
 	Components                     []Component
 	CalendarProperties             []CalendarProperty
 	unknownCalendarPropertyHandler func(cal *Calendar, state string, cl *BaseProperty) error
-	propertyParseErrorHandler      func(rawLine ContentLine, err error) (*BaseProperty, error)
+	propertyParseErrorHandler      PropertyParseErrorHandler
 }
 
 func NewCalendar() *Calendar {
@@ -704,7 +704,7 @@ func WithUnknownPropertyHandler(f func(*Calendar, string, *BaseProperty) error) 
 // Without this option, any property parse error aborts the entire calendar parse.
 // This is useful for real-world ICS feeds that contain non-RFC-compliant properties
 // (e.g. parameter names with underscores).
-func WithPropertyParseErrorHandler(f func(rawLine ContentLine, err error) (*BaseProperty, error)) ParseOption {
+func WithPropertyParseErrorHandler(f PropertyParseErrorHandler) ParseOption {
 	return func(c *Calendar) error {
 		c.propertyParseErrorHandler = f
 		return nil

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -563,9 +563,11 @@ END:VCALENDAR
 
 	// With the handler set to skip, parsing succeeds.
 	var skippedLines []string
+	var skippedErrors []error
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
 		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
 			skippedLines = append(skippedLines, string(rawLine))
+			skippedErrors = append(skippedErrors, parseErr)
 			return nil, nil // skip
 		}),
 	)
@@ -577,6 +579,9 @@ END:VCALENDAR
 	assert.Equal(t, "Test Event", cal.Events()[0].GetProperty(ComponentPropertySummary).Value)
 	assert.Len(t, skippedLines, 1)
 	assert.Contains(t, skippedLines[0], "X-TKF-PROMOTION-BUTTON")
+	// The parse error should describe the malformed parameter name.
+	assert.Len(t, skippedErrors, 1)
+	assert.Contains(t, skippedErrors[0].Error(), "missing property value for skip")
 }
 
 func TestWithPropertyParseErrorHandler_Abort(t *testing.T) {
@@ -592,13 +597,18 @@ END:VEVENT
 END:VCALENDAR
 `
 	customErr := errors.New("custom abort")
+	var receivedParseErr error
 	_, err := ParseCalendarWithOptions(strings.NewReader(input),
 		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			receivedParseErr = parseErr
 			return nil, customErr
 		}),
 	)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, customErr)
+	// The original parse error should have been passed to the handler.
+	assert.NotNil(t, receivedParseErr)
+	assert.Contains(t, receivedParseErr.Error(), "missing property value for under")
 }
 
 func TestWithPropertyParseErrorHandler_Recover(t *testing.T) {
@@ -725,6 +735,52 @@ END:VCALENDAR
 	// The valid alarm properties should still be there.
 	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyTrigger))
 	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyAction))
+}
+
+func TestWithPropertyParseErrorHandler_MultipleConsecutive(t *testing.T) {
+	// Multiple malformed properties in the same component should all be
+	// passed to the handler individually.
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+X-BAD-ONE;under_score=val:value1
+SUMMARY:Test Event
+X-BAD-TWO;another_bad=yes:value2
+X-BAD-THREE;yet_another=no:value3
+DTEND:20240101T130000Z
+END:VEVENT
+END:VCALENDAR
+`
+	var skippedLines []string
+	var skippedErrors []string
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			skippedLines = append(skippedLines, string(rawLine))
+			skippedErrors = append(skippedErrors, parseErr.Error())
+			return nil, nil // skip all
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, cal)
+	assert.Len(t, cal.Events(), 1)
+	// All three malformed properties should have been skipped.
+	assert.Len(t, skippedLines, 3)
+	assert.Contains(t, skippedLines[0], "X-BAD-ONE")
+	assert.Contains(t, skippedLines[1], "X-BAD-TWO")
+	assert.Contains(t, skippedLines[2], "X-BAD-THREE")
+	// Each error should reference the respective malformed param name.
+	assert.Contains(t, skippedErrors[0], "under")
+	assert.Contains(t, skippedErrors[1], "another")
+	assert.Contains(t, skippedErrors[2], "yet")
+	// Valid properties should still be present.
+	ev := cal.Events()[0]
+	assert.Equal(t, "Test Event", ev.GetProperty(ComponentPropertySummary).Value)
+	assert.NotNil(t, ev.GetProperty(ComponentPropertyDtStart))
+	assert.NotNil(t, ev.GetProperty(ComponentPropertyDtEnd))
 }
 
 func BenchmarkSerialize(b *testing.B) {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	_ "embed"
 	"errors"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/http"
@@ -848,6 +849,67 @@ END:VCALENDAR
 	assert.Equal(t, "Test Event", ev.GetProperty(ComponentPropertySummary).Value)
 	assert.NotNil(t, ev.GetProperty(ComponentPropertyDtStart))
 	assert.NotNil(t, ev.GetProperty(ComponentPropertyDtEnd))
+}
+
+func TestParseCalendarWithOptions_InvalidOptionType(t *testing.T) {
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+END:VCALENDAR
+`
+
+	_, err := ParseCalendarWithOptions(strings.NewReader(input), 42)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid parse option type")
+	}
+}
+
+func TestNewCalendarWithOptions_InvalidOptionType(t *testing.T) {
+	_, err := NewCalendarWithOptions(42)
+	if assert.Error(t, err) {
+		assert.Contains(t, err.Error(), "invalid parse option type")
+	}
+}
+
+func TestParseProperty_ExportedStrict(t *testing.T) {
+	line, err := ParseProperty(ContentLine("SUMMARY:ok"))
+	if !assert.NoError(t, err) {
+		return
+	}
+	if assert.NotNil(t, line) {
+		assert.Equal(t, "SUMMARY", line.IANAToken)
+		assert.Equal(t, "ok", line.Value)
+	}
+
+	_, err = ParseProperty(ContentLine("X-BAD;under_score=val:value"))
+	assert.Error(t, err)
+}
+
+func TestErrPropertySkippedBehavior(t *testing.T) {
+	parser := func(rawLine ContentLine) (*BaseProperty, error) {
+		if strings.Contains(string(rawLine), "X-SKIP") {
+			return nil, fmt.Errorf("%w: intentional", ErrPropertySkipped)
+		}
+		return parseProperty(rawLine)
+	}
+
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+X-SKIP:1
+BEGIN:VEVENT
+SUMMARY:ok
+X-SKIP:2
+END:VEVENT
+END:VCALENDAR
+`
+
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input), parser)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Len(t, cal.Events(), 1)
+	assert.Equal(t, "ok", cal.Events()[0].GetProperty(ComponentPropertySummary).Value)
 }
 
 func BenchmarkSerialize(b *testing.B) {

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -860,14 +860,46 @@ END:VCALENDAR
 
 	_, err := ParseCalendarWithOptions(strings.NewReader(input), 42)
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "invalid parse option type")
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
 	}
 }
 
 func TestNewCalendarWithOptions_InvalidOptionType(t *testing.T) {
 	_, err := NewCalendarWithOptions(42)
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "invalid parse option type")
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
+	}
+}
+
+func TestParseCalendarFromUrl_InvalidOptionType(t *testing.T) {
+	_, err := ParseCalendarFromUrl("https://example.com", 42)
+	if assert.Error(t, err) {
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
+	}
+}
+
+func TestComponentParseWithOptions_InvalidOptionType(t *testing.T) {
+	_, err := ParseComponentWithOptions(nil, nil, 42)
+	if assert.Error(t, err) {
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
+	}
+
+	_, err = GeneralParseComponentWithOptions(nil, nil, 42)
+	if assert.Error(t, err) {
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
+	}
+}
+
+func TestSerialize_InvalidOptionType(t *testing.T) {
+	_, err := parseSerializeOps([]any{42})
+	if assert.Error(t, err) {
+		assert.ErrorIs(t, err, ErrInvalidOpArg)
+		assert.Contains(t, err.Error(), "0")
 	}
 }
 

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -25,6 +25,22 @@ var (
 	TestData embed.FS
 )
 
+func captureMalformedPropertyParser(lines *[]string, next PropertyParser) PropertyParser {
+	return func(rawLine ContentLine) (*BaseProperty, error) {
+		line, err := parseProperty(rawLine)
+		if err == nil {
+			return line, nil
+		}
+		if lines != nil {
+			*lines = append(*lines, string(rawLine))
+		}
+		if next == nil {
+			return nil, nil
+		}
+		return next(rawLine)
+	}
+}
+
 func TestTimeParsing(t *testing.T) {
 	calFile, err := TestData.Open("testdata/timeparsing.ics")
 	if err != nil {
@@ -543,9 +559,9 @@ func TestIssue77(t *testing.T) {
 	}
 }
 
-func TestWithPropertyParseErrorHandler_Skip(t *testing.T) {
+func TestWithPropertyParser_Skip(t *testing.T) {
 	// Tockify-style property with underscore in parameter name.
-	// Without the handler, this aborts the entire calendar parse.
+	// Without the parser override, this aborts the entire calendar parse.
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -556,20 +572,15 @@ X-TKF-PROMOTION-BUTTON;skip_details=false;button_text=Buy Tickets:https://exampl
 END:VEVENT
 END:VCALENDAR
 `
-	// Verify it fails without the handler.
+	// Verify it fails without the parser override.
 	_, err := ParseCalendar(strings.NewReader(input))
 	assert.Error(t, err, "should fail without handler")
 	assert.Contains(t, err.Error(), "missing property value for skip")
 
-	// With the handler set to skip, parsing succeeds.
+	// With the parser override set to skip, parsing succeeds.
 	var skippedLines []string
-	var skippedErrors []error
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			skippedLines = append(skippedLines, string(rawLine))
-			skippedErrors = append(skippedErrors, parseErr)
-			return nil, nil // skip
-		}),
+		captureMalformedPropertyParser(&skippedLines, SkipPropertyParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -579,13 +590,10 @@ END:VCALENDAR
 	assert.Equal(t, "Test Event", cal.Events()[0].GetProperty(ComponentPropertySummary).Value)
 	assert.Len(t, skippedLines, 1)
 	assert.Contains(t, skippedLines[0], "X-TKF-PROMOTION-BUTTON")
-	// The parse error should describe the malformed parameter name.
-	assert.Len(t, skippedErrors, 1)
-	assert.Contains(t, skippedErrors[0].Error(), "missing property value for skip")
 }
 
-func TestWithPropertyParseErrorHandler_Abort(t *testing.T) {
-	// Handler that returns an error aborts parsing with that error.
+func TestWithPropertyParser_Abort(t *testing.T) {
+	// Parser override that returns an error aborts parsing with that error.
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -597,22 +605,21 @@ END:VEVENT
 END:VCALENDAR
 `
 	customErr := errors.New("custom abort")
-	var receivedParseErr error
 	_, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			receivedParseErr = parseErr
-			return nil, customErr
-		}),
+		func(rawLine ContentLine) (*BaseProperty, error) {
+			_, parseErr := parseProperty(rawLine)
+			if parseErr != nil {
+				return nil, customErr
+			}
+			return nil, nil
+		},
 	)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, customErr)
-	// The original parse error should have been passed to the handler.
-	assert.NotNil(t, receivedParseErr)
-	assert.Contains(t, receivedParseErr.Error(), "missing property value for under")
 }
 
-func TestWithPropertyParseErrorHandler_Recover(t *testing.T) {
-	// Handler that returns a replacement property.
+func TestWithPropertyParser_Recover(t *testing.T) {
+	// Parser override that returns a replacement property.
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -624,21 +631,7 @@ END:VEVENT
 END:VCALENDAR
 `
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			// Recover by extracting just the property name and value,
-			// discarding the malformed parameters.
-			s := string(rawLine)
-			colonIdx := strings.Index(s, ":")
-			semiIdx := strings.Index(s, ";")
-			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
-				return &BaseProperty{
-					IANAToken:      s[:semiIdx],
-					Value:          s[colonIdx+1:],
-					ICalParameters: map[string][]string{},
-				}, nil
-			}
-			return nil, nil // skip if recovery fails
-		}),
+		FallbackParser(LooseParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -653,7 +646,37 @@ END:VCALENDAR
 	}
 }
 
-func TestWithPropertyParseErrorHandler_CalendarLevel(t *testing.T) {
+func TestWithPropertyParser_FallbackChain(t *testing.T) {
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+X-BAD;under_score=val:the-value
+END:VEVENT
+END:VCALENDAR
+`
+	var firstFallbackCalls int
+	parser := FallbackParser(
+		func(rawLine ContentLine) (*BaseProperty, error) {
+			firstFallbackCalls++
+			return nil, nil
+		},
+		LooseParser,
+	)
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input), parser)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.Equal(t, 1, firstFallbackCalls)
+	badProp := cal.Events()[0].GetProperty("X-BAD")
+	if assert.NotNil(t, badProp) {
+		assert.Equal(t, "the-value", badProp.Value)
+	}
+}
+
+func TestWithPropertyParser_CalendarLevel(t *testing.T) {
 	// Malformed property at the calendar level (outside any component).
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
@@ -667,10 +690,7 @@ END:VCALENDAR
 `
 	var skippedLines []string
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			skippedLines = append(skippedLines, string(rawLine))
-			return nil, nil
-		}),
+		captureMalformedPropertyParser(&skippedLines, SkipPropertyParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -682,8 +702,8 @@ END:VCALENDAR
 	assert.Len(t, cal.Events(), 1)
 }
 
-func TestWithPropertyParseErrorHandler_NoHandler(t *testing.T) {
-	// Without the handler, malformed properties still cause errors (backward compat).
+func TestWithPropertyParser_NoHandler(t *testing.T) {
+	// Without the parser override, malformed properties still cause errors (backward compat).
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -698,8 +718,8 @@ END:VCALENDAR
 	assert.Error(t, err)
 }
 
-func TestWithPropertyParseErrorHandler_NestedComponent(t *testing.T) {
-	// Handler should propagate into nested components (e.g. VALARM inside VEVENT).
+func TestWithPropertyParser_NestedComponent(t *testing.T) {
+	// Parser override should propagate into nested components (e.g. VALARM inside VEVENT).
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -717,10 +737,7 @@ END:VCALENDAR
 `
 	var skippedLines []string
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			skippedLines = append(skippedLines, string(rawLine))
-			return nil, nil
-		}),
+		captureMalformedPropertyParser(&skippedLines, SkipPropertyParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -737,7 +754,7 @@ END:VCALENDAR
 	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyAction))
 }
 
-func TestWithPropertyParseErrorHandler_CalendarLevelRecover(t *testing.T) {
+func TestWithPropertyParser_CalendarLevelRecover(t *testing.T) {
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 X-BAD-CAL;under_score=val:cal-value
@@ -746,19 +763,7 @@ END:VCALENDAR
 `
 
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			s := string(rawLine)
-			colonIdx := strings.Index(s, ":")
-			semiIdx := strings.Index(s, ";")
-			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
-				return &BaseProperty{
-					IANAToken:      s[:semiIdx],
-					Value:          s[colonIdx+1:],
-					ICalParameters: map[string][]string{},
-				}, nil
-			}
-			return nil, nil
-		}),
+		FallbackParser(LooseParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -774,7 +779,7 @@ END:VCALENDAR
 	assert.True(t, found, "expected recovered calendar-level property")
 }
 
-func TestWithPropertyParseErrorHandler_NestedComponentRecover(t *testing.T) {
+func TestWithPropertyParser_NestedComponentRecover(t *testing.T) {
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -792,19 +797,7 @@ END:VCALENDAR
 `
 
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			s := string(rawLine)
-			colonIdx := strings.Index(s, ":")
-			semiIdx := strings.Index(s, ";")
-			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
-				return &BaseProperty{
-					IANAToken:      s[:semiIdx],
-					Value:          s[colonIdx+1:],
-					ICalParameters: map[string][]string{},
-				}, nil
-			}
-			return nil, nil
-		}),
+		FallbackParser(LooseParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -820,9 +813,9 @@ END:VCALENDAR
 	}
 }
 
-func TestWithPropertyParseErrorHandler_MultipleConsecutive(t *testing.T) {
+func TestWithPropertyParser_MultipleConsecutive(t *testing.T) {
 	// Multiple malformed properties in the same component should all be
-	// passed to the handler individually.
+	// passed to the parser override individually.
 	input := `BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Test//Test//EN
@@ -837,13 +830,8 @@ END:VEVENT
 END:VCALENDAR
 `
 	var skippedLines []string
-	var skippedErrors []string
 	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
-		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
-			skippedLines = append(skippedLines, string(rawLine))
-			skippedErrors = append(skippedErrors, parseErr.Error())
-			return nil, nil // skip all
-		}),
+		captureMalformedPropertyParser(&skippedLines, SkipPropertyParser),
 	)
 	if !assert.NoError(t, err) {
 		return
@@ -855,10 +843,6 @@ END:VCALENDAR
 	assert.Contains(t, skippedLines[0], "X-BAD-ONE")
 	assert.Contains(t, skippedLines[1], "X-BAD-TWO")
 	assert.Contains(t, skippedLines[2], "X-BAD-THREE")
-	// Each error should reference the respective malformed param name.
-	assert.Contains(t, skippedErrors[0], "under")
-	assert.Contains(t, skippedErrors[1], "another")
-	assert.Contains(t, skippedErrors[2], "yet")
 	// Valid properties should still be present.
 	ev := cal.Events()[0]
 	assert.Equal(t, "Test Event", ev.GetProperty(ComponentPropertySummary).Value)

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -737,6 +737,89 @@ END:VCALENDAR
 	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyAction))
 }
 
+func TestWithPropertyParseErrorHandler_CalendarLevelRecover(t *testing.T) {
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+X-BAD-CAL;under_score=val:cal-value
+PRODID:-//Test//Test//EN
+END:VCALENDAR
+`
+
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			s := string(rawLine)
+			colonIdx := strings.Index(s, ":")
+			semiIdx := strings.Index(s, ";")
+			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
+				return &BaseProperty{
+					IANAToken:      s[:semiIdx],
+					Value:          s[colonIdx+1:],
+					ICalParameters: map[string][]string{},
+				}, nil
+			}
+			return nil, nil
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	found := false
+	for _, p := range cal.CalendarProperties {
+		if p.IANAToken == "X-BAD-CAL" {
+			found = true
+			assert.Equal(t, "cal-value", p.Value)
+		}
+	}
+	assert.True(t, found, "expected recovered calendar-level property")
+}
+
+func TestWithPropertyParseErrorHandler_NestedComponentRecover(t *testing.T) {
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+BEGIN:VALARM
+TRIGGER:-PT15M
+ACTION:DISPLAY
+X-ALARM-BAD;under_score=val:alarm-value
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+`
+
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			s := string(rawLine)
+			colonIdx := strings.Index(s, ":")
+			semiIdx := strings.Index(s, ";")
+			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
+				return &BaseProperty{
+					IANAToken:      s[:semiIdx],
+					Value:          s[colonIdx+1:],
+					ICalParameters: map[string][]string{},
+				}, nil
+			}
+			return nil, nil
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	events := cal.Events()
+	assert.Len(t, events, 1)
+	alarms := events[0].Alarms()
+	assert.Len(t, alarms, 1)
+	recovered := alarms[0].GetProperty("X-ALARM-BAD")
+	if assert.NotNil(t, recovered) {
+		assert.Equal(t, "alarm-value", recovered.Value)
+	}
+}
+
 func TestWithPropertyParseErrorHandler_MultipleConsecutive(t *testing.T) {
 	// Multiple malformed properties in the same component should all be
 	// passed to the handler individually.

--- a/calendar_test.go
+++ b/calendar_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	_ "embed"
+	"errors"
 	"io"
 	"io/fs"
 	"net/http"
@@ -540,6 +541,190 @@ func TestIssue77(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error reading file: %s", err)
 	}
+}
+
+func TestWithPropertyParseErrorHandler_Skip(t *testing.T) {
+	// Tockify-style property with underscore in parameter name.
+	// Without the handler, this aborts the entire calendar parse.
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+X-TKF-PROMOTION-BUTTON;skip_details=false;button_text=Buy Tickets:https://example.com
+END:VEVENT
+END:VCALENDAR
+`
+	// Verify it fails without the handler.
+	_, err := ParseCalendar(strings.NewReader(input))
+	assert.Error(t, err, "should fail without handler")
+	assert.Contains(t, err.Error(), "missing property value for skip")
+
+	// With the handler set to skip, parsing succeeds.
+	var skippedLines []string
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			skippedLines = append(skippedLines, string(rawLine))
+			return nil, nil // skip
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, cal)
+	assert.Len(t, cal.Events(), 1)
+	assert.Equal(t, "Test Event", cal.Events()[0].GetProperty(ComponentPropertySummary).Value)
+	assert.Len(t, skippedLines, 1)
+	assert.Contains(t, skippedLines[0], "X-TKF-PROMOTION-BUTTON")
+}
+
+func TestWithPropertyParseErrorHandler_Abort(t *testing.T) {
+	// Handler that returns an error aborts parsing with that error.
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+X-BAD;under_score=val:value
+END:VEVENT
+END:VCALENDAR
+`
+	customErr := errors.New("custom abort")
+	_, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			return nil, customErr
+		}),
+	)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, customErr)
+}
+
+func TestWithPropertyParseErrorHandler_Recover(t *testing.T) {
+	// Handler that returns a replacement property.
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+X-BAD;under_score=val:the-value
+END:VEVENT
+END:VCALENDAR
+`
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			// Recover by extracting just the property name and value,
+			// discarding the malformed parameters.
+			s := string(rawLine)
+			colonIdx := strings.Index(s, ":")
+			semiIdx := strings.Index(s, ";")
+			if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
+				return &BaseProperty{
+					IANAToken:      s[:semiIdx],
+					Value:          s[colonIdx+1:],
+					ICalParameters: map[string][]string{},
+				}, nil
+			}
+			return nil, nil // skip if recovery fails
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, cal)
+	events := cal.Events()
+	assert.Len(t, events, 1)
+	// The recovered property should be present.
+	badProp := events[0].GetProperty("X-BAD")
+	if assert.NotNil(t, badProp) {
+		assert.Equal(t, "the-value", badProp.Value)
+	}
+}
+
+func TestWithPropertyParseErrorHandler_CalendarLevel(t *testing.T) {
+	// Malformed property at the calendar level (outside any component).
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+X-BAD-CAL;under_score=val:cal-value
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+END:VEVENT
+END:VCALENDAR
+`
+	var skippedLines []string
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			skippedLines = append(skippedLines, string(rawLine))
+			return nil, nil
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, cal)
+	assert.Len(t, skippedLines, 1)
+	assert.Contains(t, skippedLines[0], "X-BAD-CAL")
+	// Valid properties should still be parsed.
+	assert.Len(t, cal.Events(), 1)
+}
+
+func TestWithPropertyParseErrorHandler_NoHandler(t *testing.T) {
+	// Without the handler, malformed properties still cause errors (backward compat).
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+X-BAD;under_score=val:value
+END:VEVENT
+END:VCALENDAR
+`
+	_, err := ParseCalendar(strings.NewReader(input))
+	assert.Error(t, err)
+}
+
+func TestWithPropertyParseErrorHandler_NestedComponent(t *testing.T) {
+	// Handler should propagate into nested components (e.g. VALARM inside VEVENT).
+	input := `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+DTSTART:20240101T120000Z
+SUMMARY:Test Event
+BEGIN:VALARM
+TRIGGER:-PT15M
+ACTION:DISPLAY
+X-ALARM-BAD;under_score=val:alarm-value
+DESCRIPTION:Reminder
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+`
+	var skippedLines []string
+	cal, err := ParseCalendarWithOptions(strings.NewReader(input),
+		WithPropertyParseErrorHandler(func(rawLine ContentLine, parseErr error) (*BaseProperty, error) {
+			skippedLines = append(skippedLines, string(rawLine))
+			return nil, nil
+		}),
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+	assert.NotNil(t, cal)
+	assert.Len(t, skippedLines, 1)
+	assert.Contains(t, skippedLines[0], "X-ALARM-BAD")
+	events := cal.Events()
+	assert.Len(t, events, 1)
+	alarms := events[0].Alarms()
+	assert.Len(t, alarms, 1)
+	// The valid alarm properties should still be there.
+	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyTrigger))
+	assert.NotNil(t, alarms[0].GetProperty(ComponentPropertyAction))
 }
 
 func BenchmarkSerialize(b *testing.B) {

--- a/components.go
+++ b/components.go
@@ -1107,15 +1107,6 @@ func GeneralParseComponent(cs *CalendarStream, startLine *BaseProperty) (Compone
 	return generalParseComponentWithHandler(cs, startLine, nil)
 }
 
-// PropertyParseErrorHandler is a function that handles property parse errors.
-// It receives the raw content line and the parse error.
-//
-// Return values:
-//   - (*BaseProperty, nil): use the returned property as a replacement
-//   - (nil, nil): skip this property silently
-//   - (nil, err): abort parsing with the given error
-type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProperty, error)
-
 func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (Component, error) {
 	var co Component
 	switch ComponentType(startLine.Value) {
@@ -1344,21 +1335,12 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, hand
 		if l == nil || len(*l) == 0 {
 			continue
 		}
-		line, err := ParseProperty(*l)
+		line, skip, err := parseProperty(*l, handler)
 		if err != nil {
-			if handler != nil {
-				var recovered *BaseProperty
-				recovered, err = handler(*l, err)
-				if err != nil {
-					return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
-				}
-				if recovered == nil {
-					continue // skip this property
-				}
-				line = recovered
-			} else {
-				return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
-			}
+			return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
+		}
+		if skip {
+			continue
 		}
 		if line == nil {
 			return cb, errors.New("parsing component line")

--- a/components.go
+++ b/components.go
@@ -1113,7 +1113,8 @@ func GeneralParseComponentWithOptions(cs *CalendarStream, startLine *BasePropert
 
 func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
 	parser := parseProperty
-	for _, opt := range opts {
+	var co Component
+	for i, opt := range opts {
 		switch opt := opt.(type) {
 		case PropertyParser:
 			if opt != nil {
@@ -1123,9 +1124,10 @@ func generalParseComponentWithHandler(cs *CalendarStream, startLine *BasePropert
 			if opt != nil {
 				parser = PropertyParser(opt)
 			}
+		default:
+			return co, fmt.Errorf("invalid option type at index %d: %T", i, opt)
 		}
 	}
-	var co Component
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
 		return nil, errors.New("malformed calendar; vcalendar not where expected")

--- a/components.go
+++ b/components.go
@@ -1125,7 +1125,7 @@ func generalParseComponentWithHandler(cs *CalendarStream, startLine *BasePropert
 				parser = PropertyParser(opt)
 			}
 		default:
-			return co, fmt.Errorf("invalid option type at index %d: %T", i, opt)
+			return co, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
 		}
 	}
 	switch ComponentType(startLine.Value) {
@@ -1356,7 +1356,7 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 				parser = PropertyParser(opt)
 			}
 		default:
-			return cb, fmt.Errorf("invalid option type at index %d: %T", i, opt)
+			return cb, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
 		}
 	}
 	cont := true

--- a/components.go
+++ b/components.go
@@ -1124,7 +1124,7 @@ func generalParseComponentWithHandler(cs *CalendarStream, startLine *BasePropert
 	case ComponentVEvent:
 		r, rerr := parseComponentWithHandler(cs, startLine, handler)
 		if rerr != nil {
-			return nil, fmt.Errorf("failed to parse event: %w", rerr)
+			return nil, rerr
 		}
 		co = &VEvent{ComponentBase: r}
 	case ComponentVTodo:

--- a/components.go
+++ b/components.go
@@ -1118,7 +1118,6 @@ type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProper
 
 func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (Component, error) {
 	var co Component
-	var err error
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
 		return nil, errors.New("malformed calendar; vcalendar not where expected")
@@ -1177,7 +1176,7 @@ func generalParseComponentWithHandler(cs *CalendarStream, startLine *BasePropert
 		}
 		co = &GeneralComponent{ComponentBase: r, Token: startLine.Value}
 	}
-	return co, err
+	return co, nil
 }
 
 func ParseVEvent(cs *CalendarStream, startLine *BaseProperty) *VEvent {

--- a/components.go
+++ b/components.go
@@ -1104,7 +1104,7 @@ func (general *GeneralComponent) SerializeTo(w io.Writer, serialConfig *Serializ
 }
 
 func GeneralParseComponent(cs *CalendarStream, startLine *BaseProperty) (Component, error) {
-	return generalParseComponentWithHandler(cs, startLine)
+	return generalParseComponentWithHandler(cs, startLine, parseProperty)
 }
 
 func GeneralParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
@@ -1112,60 +1112,73 @@ func GeneralParseComponentWithOptions(cs *CalendarStream, startLine *BasePropert
 }
 
 func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
+	parser := parseProperty
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case PropertyParser:
+			if opt != nil {
+				parser = opt
+			}
+		case func(ContentLine) (*BaseProperty, error):
+			if opt != nil {
+				parser = PropertyParser(opt)
+			}
+		}
+	}
 	var co Component
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
 		return nil, errors.New("malformed calendar; vcalendar not where expected")
 	case ComponentVEvent:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VEvent{ComponentBase: r}
 	case ComponentVTodo:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VTodo{ComponentBase: r}
 	case ComponentVJournal:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VJournal{ComponentBase: r}
 	case ComponentVFreeBusy:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VBusy{ComponentBase: r}
 	case ComponentVTimezone:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VTimezone{ComponentBase: r}
 	case ComponentVAlarm:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VAlarm{ComponentBase: r}
 	case ComponentStandard:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &Standard{ComponentBase: r}
 	case ComponentDaylight:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &Daylight{ComponentBase: r}
 	default:
-		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
+		r, rerr := parseComponentWithHandler(cs, startLine, parser)
 		if rerr != nil {
 			return nil, rerr
 		}
@@ -1328,7 +1341,6 @@ func ParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts
 }
 
 func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
-	cb := ComponentBase{}
 	parser := parseProperty
 	for _, opt := range opts {
 		switch opt := opt.(type) {
@@ -1342,6 +1354,7 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 			}
 		}
 	}
+	cb := ComponentBase{}
 	cont := true
 	for ln := 0; cont; ln++ {
 		l, err := cs.ReadLine()
@@ -1358,6 +1371,9 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 		}
 		line, err := parser(*l)
 		if err != nil {
+			if errors.Is(err, ErrPropertySkipped) {
+				continue
+			}
 			return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
 		}
 		if line == nil {
@@ -1372,7 +1388,7 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 				return cb, errors.New("unbalanced end")
 			}
 		case "BEGIN":
-			co, err := generalParseComponentWithHandler(cs, line, opts...)
+			co, err := generalParseComponentWithHandler(cs, line, parser)
 			if err != nil {
 				return cb, err
 			}

--- a/components.go
+++ b/components.go
@@ -1104,29 +1104,78 @@ func (general *GeneralComponent) SerializeTo(w io.Writer, serialConfig *Serializ
 }
 
 func GeneralParseComponent(cs *CalendarStream, startLine *BaseProperty) (Component, error) {
+	return generalParseComponentWithHandler(cs, startLine, nil)
+}
+
+// PropertyParseErrorHandler is a function that handles property parse errors.
+// It receives the raw content line and the parse error.
+//
+// Return values:
+//   - (*BaseProperty, nil): use the returned property as a replacement
+//   - (nil, nil): skip this property silently
+//   - (nil, err): abort parsing with the given error
+type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProperty, error)
+
+func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (Component, error) {
 	var co Component
 	var err error
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
 		return nil, errors.New("malformed calendar; vcalendar not where expected")
 	case ComponentVEvent:
-		co, err = ParseVEventWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, fmt.Errorf("failed to parse event: %w", rerr)
+		}
+		co = &VEvent{ComponentBase: r}
 	case ComponentVTodo:
-		co, err = ParseVTodoWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &VTodo{ComponentBase: r}
 	case ComponentVJournal:
-		co, err = ParseVJournalWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &VJournal{ComponentBase: r}
 	case ComponentVFreeBusy:
-		co, err = ParseVBusyWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &VBusy{ComponentBase: r}
 	case ComponentVTimezone:
-		co, err = ParseVTimezoneWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &VTimezone{ComponentBase: r}
 	case ComponentVAlarm:
-		co, err = ParseVAlarmWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &VAlarm{ComponentBase: r}
 	case ComponentStandard:
-		co, err = ParseStandardWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &Standard{ComponentBase: r}
 	case ComponentDaylight:
-		co, err = ParseDaylightWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &Daylight{ComponentBase: r}
 	default:
-		co, err = ParseGeneralComponentWithError(cs, startLine)
+		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		if rerr != nil {
+			return nil, rerr
+		}
+		co = &GeneralComponent{ComponentBase: r, Token: startLine.Value}
 	}
 	return co, err
 }
@@ -1277,6 +1326,10 @@ func ParseGeneralComponentWithError(cs *CalendarStream, startLine *BaseProperty)
 }
 
 func ParseComponent(cs *CalendarStream, startLine *BaseProperty) (ComponentBase, error) {
+	return parseComponentWithHandler(cs, startLine, nil)
+}
+
+func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (ComponentBase, error) {
 	cb := ComponentBase{}
 	cont := true
 	for ln := 0; cont; ln++ {
@@ -1294,7 +1347,19 @@ func ParseComponent(cs *CalendarStream, startLine *BaseProperty) (ComponentBase,
 		}
 		line, err := ParseProperty(*l)
 		if err != nil {
-			return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
+			if handler != nil {
+				var recovered *BaseProperty
+				recovered, err = handler(*l, err)
+				if err != nil {
+					return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
+				}
+				if recovered == nil {
+					continue // skip this property
+				}
+				line = recovered
+			} else {
+				return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
+			}
 		}
 		if line == nil {
 			return cb, errors.New("parsing component line")
@@ -1308,7 +1373,7 @@ func ParseComponent(cs *CalendarStream, startLine *BaseProperty) (ComponentBase,
 				return cb, errors.New("unbalanced end")
 			}
 		case "BEGIN":
-			co, err := GeneralParseComponent(cs, line)
+			co, err := generalParseComponentWithHandler(cs, line, handler)
 			if err != nil {
 				return cb, err
 			}

--- a/components.go
+++ b/components.go
@@ -1342,6 +1342,7 @@ func ParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts
 
 func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
 	parser := parseProperty
+	cb := ComponentBase{}
 	for i, opt := range opts {
 		switch opt := opt.(type) {
 		case PropertyParser:
@@ -1356,7 +1357,6 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 			return cb, fmt.Errorf("invalid option type at index %d: %T", i, opt)
 		}
 	}
-	cb := ComponentBase{}
 	cont := true
 	for ln := 0; cont; ln++ {
 		l, err := cs.ReadLine()

--- a/components.go
+++ b/components.go
@@ -1112,21 +1112,10 @@ func GeneralParseComponentWithOptions(cs *CalendarStream, startLine *BasePropert
 }
 
 func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
-	parser := parseProperty
+	parser, err := parsePropertyParserOptions(parseProperty, opts...)
 	var co Component
-	for i, opt := range opts {
-		switch opt := opt.(type) {
-		case PropertyParser:
-			if opt != nil {
-				parser = opt
-			}
-		case func(ContentLine) (*BaseProperty, error):
-			if opt != nil {
-				parser = PropertyParser(opt)
-			}
-		default:
-			return co, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
-		}
+	if err != nil {
+		return co, err
 	}
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
@@ -1343,21 +1332,10 @@ func ParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts
 }
 
 func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
-	parser := parseProperty
+	parser, err := parsePropertyParserOptions(parseProperty, opts...)
 	cb := ComponentBase{}
-	for i, opt := range opts {
-		switch opt := opt.(type) {
-		case PropertyParser:
-			if opt != nil {
-				parser = opt
-			}
-		case func(ContentLine) (*BaseProperty, error):
-			if opt != nil {
-				parser = PropertyParser(opt)
-			}
-		default:
-			return cb, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
-		}
+	if err != nil {
+		return cb, err
 	}
 	cont := true
 	for ln := 0; cont; ln++ {

--- a/components.go
+++ b/components.go
@@ -1342,7 +1342,7 @@ func ParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts
 
 func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
 	parser := parseProperty
-	for _, opt := range opts {
+	for i, opt := range opts {
 		switch opt := opt.(type) {
 		case PropertyParser:
 			if opt != nil {
@@ -1352,6 +1352,8 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts
 			if opt != nil {
 				parser = PropertyParser(opt)
 			}
+		default:
+			return cb, fmt.Errorf("invalid option type at index %d: %T", i, opt)
 		}
 	}
 	cb := ComponentBase{}

--- a/components.go
+++ b/components.go
@@ -1104,64 +1104,68 @@ func (general *GeneralComponent) SerializeTo(w io.Writer, serialConfig *Serializ
 }
 
 func GeneralParseComponent(cs *CalendarStream, startLine *BaseProperty) (Component, error) {
-	return generalParseComponentWithHandler(cs, startLine, nil)
+	return generalParseComponentWithHandler(cs, startLine)
 }
 
-func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (Component, error) {
+func GeneralParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
+	return generalParseComponentWithHandler(cs, startLine, opts...)
+}
+
+func generalParseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (Component, error) {
 	var co Component
 	switch ComponentType(startLine.Value) {
 	case ComponentVCalendar:
 		return nil, errors.New("malformed calendar; vcalendar not where expected")
 	case ComponentVEvent:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VEvent{ComponentBase: r}
 	case ComponentVTodo:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VTodo{ComponentBase: r}
 	case ComponentVJournal:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VJournal{ComponentBase: r}
 	case ComponentVFreeBusy:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VBusy{ComponentBase: r}
 	case ComponentVTimezone:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VTimezone{ComponentBase: r}
 	case ComponentVAlarm:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &VAlarm{ComponentBase: r}
 	case ComponentStandard:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &Standard{ComponentBase: r}
 	case ComponentDaylight:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
 		co = &Daylight{ComponentBase: r}
 	default:
-		r, rerr := parseComponentWithHandler(cs, startLine, handler)
+		r, rerr := parseComponentWithHandler(cs, startLine, opts...)
 		if rerr != nil {
 			return nil, rerr
 		}
@@ -1316,11 +1320,28 @@ func ParseGeneralComponentWithError(cs *CalendarStream, startLine *BaseProperty)
 }
 
 func ParseComponent(cs *CalendarStream, startLine *BaseProperty) (ComponentBase, error) {
-	return parseComponentWithHandler(cs, startLine, nil)
+	return parseComponentWithHandler(cs, startLine)
 }
 
-func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, handler PropertyParseErrorHandler) (ComponentBase, error) {
+func ParseComponentWithOptions(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
+	return parseComponentWithHandler(cs, startLine, opts...)
+}
+
+func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
 	cb := ComponentBase{}
+	parser := parseProperty
+	for _, opt := range opts {
+		switch opt := opt.(type) {
+		case PropertyParser:
+			if opt != nil {
+				parser = opt
+			}
+		case func(ContentLine) (*BaseProperty, error):
+			if opt != nil {
+				parser = PropertyParser(opt)
+			}
+		}
+	}
 	cont := true
 	for ln := 0; cont; ln++ {
 		l, err := cs.ReadLine()
@@ -1335,15 +1356,12 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, hand
 		if l == nil || len(*l) == 0 {
 			continue
 		}
-		line, skip, err := parseProperty(*l, handler)
+		line, err := parser(*l)
 		if err != nil {
 			return cb, fmt.Errorf("parsing component property %d: %w", ln, err)
 		}
-		if skip {
-			continue
-		}
 		if line == nil {
-			return cb, errors.New("parsing component line")
+			continue
 		}
 		switch line.IANAToken {
 		case "END":
@@ -1354,7 +1372,7 @@ func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, hand
 				return cb, errors.New("unbalanced end")
 			}
 		case "BEGIN":
-			co, err := generalParseComponentWithHandler(cs, line, handler)
+			co, err := generalParseComponentWithHandler(cs, line, opts...)
 			if err != nil {
 				return cb, err
 			}

--- a/errors.go
+++ b/errors.go
@@ -6,4 +6,7 @@ var (
 	// ErrorPropertyNotFound is the error returned if the requested valid
 	// property is not set.
 	ErrorPropertyNotFound = errors.New("property not found")
+
+	// ErrPropertySkipped marks a parser decision to skip a malformed line and continue.
+	ErrPropertySkipped = errors.New("property skipped")
 )

--- a/errors.go
+++ b/errors.go
@@ -7,6 +7,9 @@ var (
 	// property is not set.
 	ErrorPropertyNotFound = errors.New("property not found")
 
+	// ErrInvalidOpArg marks an invalid variadic option argument.
+	ErrInvalidOpArg = errors.New("invalid option argument")
+
 	// ErrPropertySkipped marks a parser decision to skip a malformed line and continue.
 	ErrPropertySkipped = errors.New("property skipped")
 )

--- a/property.go
+++ b/property.go
@@ -307,15 +307,18 @@ func SkipPropertyParser(rawLine ContentLine) (*BaseProperty, error) {
 func LooseParser(rawLine ContentLine) (*BaseProperty, error) {
 	s := string(rawLine)
 	colonIdx := strings.Index(s, ":")
-	semiIdx := strings.Index(s, ";")
-	if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
-		return &BaseProperty{
-			IANAToken:      s[:semiIdx],
-			Value:          s[colonIdx+1:],
-			ICalParameters: map[string][]string{},
-		}, nil
+	if colonIdx <= 0 {
+		return nil, fmt.Errorf("%w: unable to recover property (no colon)", ErrPropertySkipped)
 	}
-	return nil, fmt.Errorf("%w: unable to recover property", ErrPropertySkipped)
+	tokenEnd := colonIdx
+	if semiIdx := strings.Index(s, ";"); semiIdx > 0 && semiIdx < colonIdx {
+		tokenEnd = semiIdx
+	}
+	return &BaseProperty{
+		IANAToken:      s[:tokenEnd],
+		Value:          s[colonIdx+1:],
+		ICalParameters: map[string][]string{},
+	}, nil
 }
 
 // FallbackParser builds an alternative to the default strict parser path used by ParseCalendar and ParseComponent.

--- a/property.go
+++ b/property.go
@@ -283,40 +283,70 @@ func init() {
 
 type ContentLine string
 
+// PropertyParseErrorHandler is a function that handles property parse errors.
+// It receives the raw content line and the parse error.
+//
+// Return values:
+//   - (*BaseProperty, nil): use the returned property as a replacement
+//   - (nil, nil): skip this property silently
+//   - (nil, err): abort parsing with the given error
+type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProperty, error)
+
 func ParseProperty(contentLine ContentLine) (*BaseProperty, error) {
+	line, _, err := parseProperty(contentLine, nil)
+	return line, err
+}
+
+func parseProperty(contentLine ContentLine, handler PropertyParseErrorHandler) (*BaseProperty, bool, error) {
 	r := &BaseProperty{
 		ICalParameters: map[string][]string{},
 	}
 	tokenPos := propertyIanaTokenReg.FindIndex([]byte(contentLine))
 	if tokenPos == nil {
-		return nil, nil
+		return nil, false, nil
 	}
 	p := 0
 	r.IANAToken = string(contentLine[p+tokenPos[0] : p+tokenPos[1]])
 	p += tokenPos[1]
 	for {
 		if p >= len(contentLine) {
-			return nil, nil
+			return nil, false, nil
 		}
 		switch rune(contentLine[p]) {
 		case ':':
-			return parsePropertyValue(r, string(contentLine), p+1), nil
+			return parsePropertyValue(r, string(contentLine), p+1), false, nil
 		case ';':
 			var np int
 			var err error
 			t := r.IANAToken
 			r, np, err = parsePropertyParam(r, string(contentLine), p+1)
 			if err != nil {
-				return nil, fmt.Errorf("parsing property %s: %w", t, err)
+				parseErr := fmt.Errorf("parsing property %s: %w", t, err)
+				return recoverProperty(contentLine, parseErr, handler)
 			}
 			if r == nil {
-				return nil, nil
+				return nil, false, nil
 			}
 			p = np
 		default:
-			return nil, nil
+			return nil, false, nil
 		}
 	}
+}
+
+func recoverProperty(contentLine ContentLine, parseErr error, handler PropertyParseErrorHandler) (*BaseProperty, bool, error) {
+	if handler == nil {
+		return nil, false, parseErr
+	}
+
+	recovered, err := handler(contentLine, parseErr)
+	if err != nil {
+		return nil, false, err
+	}
+	if recovered == nil {
+		return nil, true, nil
+	}
+	return recovered, false, nil
 }
 
 func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProperty, int, error) {

--- a/property.go
+++ b/property.go
@@ -321,12 +321,8 @@ func LooseParser(rawLine ContentLine) (*BaseProperty, error) {
 // FallbackParser builds an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
 // It tries the strict parser first, then each supplied fallback parser in order.
 func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) PropertyParser {
+	parsers := append([]PropertyParser{fallback}, fallbacks...)
 	return func(rawLine ContentLine) (*BaseProperty, error) {
-		line, err := parseProperty(rawLine)
-		if err == nil {
-			return line, nil
-		}
-		parsers := append([]PropertyParser{fallback}, fallbacks...)
 		for _, p := range parsers {
 			if p == nil {
 				continue
@@ -342,7 +338,7 @@ func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) Proper
 				return line, nil
 			}
 		}
-		return nil, fmt.Errorf("%w: %v", ErrPropertySkipped, err)
+		return nil, fmt.Errorf("%w: no capable parsers found", ErrPropertySkipped)
 	}
 }
 

--- a/property.go
+++ b/property.go
@@ -310,7 +310,7 @@ func LooseParser(rawLine ContentLine) (*BaseProperty, error) {
 			ICalParameters: map[string][]string{},
 		}, nil
 	}
-	return nil, nil
+	return nil, fmt.Errorf("%w: unable to recover property", ErrPropertySkipped)
 }
 
 // FallbackParser builds an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
@@ -328,13 +328,16 @@ func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) Proper
 			}
 			line, err := p(rawLine)
 			if err != nil {
+				if errors.Is(err, ErrPropertySkipped) {
+					continue
+				}
 				return nil, err
 			}
 			if line != nil {
 				return line, nil
 			}
 		}
-		return nil, nil
+		return nil, fmt.Errorf("%w: %v", ErrPropertySkipped, err)
 	}
 }
 

--- a/property.go
+++ b/property.go
@@ -323,6 +323,10 @@ func LooseParser(rawLine ContentLine) (*BaseProperty, error) {
 func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) PropertyParser {
 	parsers := append([]PropertyParser{fallback}, fallbacks...)
 	return func(rawLine ContentLine) (*BaseProperty, error) {
+		line, err := parseProperty(rawLine)
+		if err == nil {
+			return line, nil
+		}
 		for _, p := range parsers {
 			if p == nil {
 				continue

--- a/property.go
+++ b/property.go
@@ -349,6 +349,24 @@ func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) Proper
 	}
 }
 
+func parsePropertyParserOptions(current PropertyParser, opts ...any) (PropertyParser, error) {
+	for i, opt := range opts {
+		switch opt := opt.(type) {
+		case PropertyParser:
+			if opt != nil {
+				current = opt
+			}
+		case func(ContentLine) (*BaseProperty, error):
+			if opt != nil {
+				current = PropertyParser(opt)
+			}
+		default:
+			return current, fmt.Errorf("%w %d: %T", ErrInvalidOpArg, i, opt)
+		}
+	}
+	return current, nil
+}
+
 func parseProperty(contentLine ContentLine) (*BaseProperty, error) {
 	r := &BaseProperty{
 		ICalParameters: map[string][]string{},

--- a/property.go
+++ b/property.go
@@ -287,6 +287,11 @@ type ContentLine string
 // It receives the raw content line and can either recover, skip, or abort.
 type PropertyParser func(rawLine ContentLine) (*BaseProperty, error)
 
+// ParseProperty parses a single RFC5545 content line using strict parsing rules.
+func ParseProperty(contentLine ContentLine) (*BaseProperty, error) {
+	return parseProperty(contentLine)
+}
+
 // SkipPropertyParser is an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
 // It returns parsed properties when the line is valid and skips malformed lines.
 func SkipPropertyParser(rawLine ContentLine) (*BaseProperty, error) {

--- a/property.go
+++ b/property.go
@@ -283,70 +283,95 @@ func init() {
 
 type ContentLine string
 
-// PropertyParseErrorHandler is a function that handles property parse errors.
-// It receives the raw content line and the parse error.
-//
-// Return values:
-//   - (*BaseProperty, nil): use the returned property as a replacement
-//   - (nil, nil): skip this property silently
-//   - (nil, err): abort parsing with the given error
-type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProperty, error)
+// PropertyParser is an optional replacement parser for malformed content lines.
+// It receives the raw content line and can either recover, skip, or abort.
+type PropertyParser func(rawLine ContentLine) (*BaseProperty, error)
 
-func ParseProperty(contentLine ContentLine) (*BaseProperty, error) {
-	line, _, err := parseProperty(contentLine, nil)
-	return line, err
+// SkipPropertyParser is an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
+// It returns parsed properties when the line is valid and skips malformed lines.
+func SkipPropertyParser(rawLine ContentLine) (*BaseProperty, error) {
+	line, err := parseProperty(rawLine)
+	if err != nil {
+		return nil, nil
+	}
+	return line, nil
 }
 
-func parseProperty(contentLine ContentLine, handler PropertyParseErrorHandler) (*BaseProperty, bool, error) {
+// LooseParser is an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
+// It preserves the property token and value when malformed parameters prevent a full parse.
+func LooseParser(rawLine ContentLine) (*BaseProperty, error) {
+	s := string(rawLine)
+	colonIdx := strings.Index(s, ":")
+	semiIdx := strings.Index(s, ";")
+	if colonIdx > 0 && semiIdx > 0 && semiIdx < colonIdx {
+		return &BaseProperty{
+			IANAToken:      s[:semiIdx],
+			Value:          s[colonIdx+1:],
+			ICalParameters: map[string][]string{},
+		}, nil
+	}
+	return nil, nil
+}
+
+// FallbackParser builds an alternative to the default strict parser path used by ParseCalendar and ParseComponent.
+// It tries the strict parser first, then each supplied fallback parser in order.
+func FallbackParser(fallback PropertyParser, fallbacks ...PropertyParser) PropertyParser {
+	return func(rawLine ContentLine) (*BaseProperty, error) {
+		line, err := parseProperty(rawLine)
+		if err == nil {
+			return line, nil
+		}
+		parsers := append([]PropertyParser{fallback}, fallbacks...)
+		for _, p := range parsers {
+			if p == nil {
+				continue
+			}
+			line, err := p(rawLine)
+			if err != nil {
+				return nil, err
+			}
+			if line != nil {
+				return line, nil
+			}
+		}
+		return nil, nil
+	}
+}
+
+func parseProperty(contentLine ContentLine) (*BaseProperty, error) {
 	r := &BaseProperty{
 		ICalParameters: map[string][]string{},
 	}
 	tokenPos := propertyIanaTokenReg.FindIndex([]byte(contentLine))
 	if tokenPos == nil {
-		return nil, false, nil
+		return nil, fmt.Errorf("invalid property token in %q", contentLine)
 	}
 	p := 0
 	r.IANAToken = string(contentLine[p+tokenPos[0] : p+tokenPos[1]])
 	p += tokenPos[1]
 	for {
 		if p >= len(contentLine) {
-			return nil, false, nil
+			return nil, fmt.Errorf("unexpected end of property %s", r.IANAToken)
 		}
 		switch rune(contentLine[p]) {
 		case ':':
-			return parsePropertyValue(r, string(contentLine), p+1), false, nil
+			return parsePropertyValue(r, string(contentLine), p+1), nil
 		case ';':
 			var np int
 			var err error
 			t := r.IANAToken
 			r, np, err = parsePropertyParam(r, string(contentLine), p+1)
 			if err != nil {
-				parseErr := fmt.Errorf("parsing property %s: %w", t, err)
-				return recoverProperty(contentLine, parseErr, handler)
+				return nil, fmt.Errorf("parsing property %s: %w", t, err)
 			}
 			if r == nil {
-				return nil, false, nil
+				return nil, fmt.Errorf("parsing property %s: invalid property", t)
 			}
 			p = np
 		default:
-			return nil, false, nil
+			return nil, fmt.Errorf("parsing property %s: unexpected character %q", r.IANAToken, contentLine[p])
 		}
 	}
-}
-
-func recoverProperty(contentLine ContentLine, parseErr error, handler PropertyParseErrorHandler) (*BaseProperty, bool, error) {
-	if handler == nil {
-		return nil, false, parseErr
-	}
-
-	recovered, err := handler(contentLine, parseErr)
-	if err != nil {
-		return nil, false, err
-	}
-	if recovered == nil {
-		return nil, true, nil
-	}
-	return recovered, false, nil
 }
 
 func parsePropertyParam(r *BaseProperty, contentLine string, p int) (*BaseProperty, int, error) {

--- a/property_test.go
+++ b/property_test.go
@@ -89,7 +89,7 @@ func TestPropertyParse(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			v, err := ParseProperty(ContentLine(test.Input))
+			v, err := parseProperty(ContentLine(test.Input))
 			test.Expected(t, v, err)
 		})
 	}


### PR DESCRIPTION
## Summary

Adds a new `WithPropertyParseErrorHandler` `ParseOption` that lets callers handle property-level parse errors (skip, recover, or abort) without aborting the entire calendar parse.

This follows the existing `WithUnknownPropertyHandler` pattern exactly — same API shape, same storage (field on `Calendar`), same threading through parse logic.

**Note:** This PR was authored by an AI agent (claude-opus-4.6) and has not yet been thoroughly reviewed by the repository owner (RKelln). A human review will follow shortly. We wanted to open the conversation early to get your feedback on the approach.

## Motivation

Real-world ICS feeds (e.g. Tockify) contain properties with non-RFC-compliant parameter names:

```
X-TKF-PROMOTION-BUTTON;skip_details=false;button_text=Buy Tickets:https://...
```

RFC 5545 §3.1 defines IANA tokens as `1*(ALPHA / DIGIT / "-")` — no underscore. The library correctly rejects these, but the error propagates through `ParseProperty` → `ParseComponent` → entire calendar parse aborts.

The existing `WithUnknownPropertyHandler` doesn't help here because it fires **after** `ParseProperty()` succeeds. The error occurs **inside** `ParseProperty()` during parameter parsing — the handler never gets a chance to run.

This is blocking ~2,900 events in our project from a major Toronto events aggregator.

## Approach

We considered three approaches:

1. **Widen the IANA token regex** to allow `_` — rejected because it violates RFC 5545, isn't opt-in, and could mask other parse errors.
2. **Pre-process raw ICS bytes** before parsing — rejected because Tockify line-folds these properties, requiring us to duplicate the library's unfolding logic.
3. **`WithPropertyParseErrorHandler` callback** (this PR) — opt-in, general, follows established patterns.

### Handler signature

```go
type PropertyParseErrorHandler func(rawLine ContentLine, err error) (*BaseProperty, error)
```

- `(nil, nil)` → skip the property silently
- `(*prop, nil)` → use the returned property as a replacement
- `(_, err)` → abort parsing with the error

We chose the simplest signature (raw content line + error) over alternatives that expose partial parse state. This keeps the API stable and easy to understand. A more sophisticated handler signature can always be added later if needed.

## Changes

**`calendar.go`:**
- New `PropertyParseErrorHandler` type (exported)
- New `WithPropertyParseErrorHandler` `ParseOption` constructor
- `propertyParseErrorHandler` field on `Calendar`
- Handler invocation in `ParseCalendarWithOptions` when `ParseProperty` returns error

**`components.go`:**
- New unexported `generalParseComponentWithHandler` and `parseComponentWithHandler` — handler-aware variants of the existing functions
- `GeneralParseComponent` and `ParseComponent` become thin wrappers delegating to handler-aware variants with `nil` handler (backward compatible)
- Handler propagated through nested component parsing (e.g. VALARM inside VEVENT)

## Design decisions

- **Default behavior unchanged:** Without the option, parsing is identical to current behavior. All existing tests pass without modification.
- **RFC-compliant by default:** The library still correctly rejects non-compliant tokens unless the caller explicitly opts in to leniency.
- **Small, focused diff:** ~80 lines of library code, no API removals, no breaking changes.
- **6 new tests:** Skip, Abort, Recover, CalendarLevel, NoHandler (backward compat), NestedComponent.

## Related issues

- #71, #73, #109 — these discuss sentinel errors / `errors.Is()` support. This PR is complementary: it addresses skip-and-continue behavior at the property level, not error type improvements.

## Usage example

```go
cal, err := ics.ParseCalendarWithOptions(reader,
    ics.WithPropertyParseErrorHandler(func(rawLine ics.ContentLine, parseErr error) (*ics.BaseProperty, error) {
        log.Printf("skipping malformed property: %s", parseErr)
        return nil, nil // skip
    }),
)
```