### PR TITLE
ci: update checkout action to v4 in goleaks workflow

### DIFF
--- a/.github/workflows/goleaks.yml
+++ b/.github/workflows/goleaks.yml
@@ -4,7 +4,9 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: gitleaks-action
       uses: zricethezav/gitleaks-action@master
       env:


### PR DESCRIPTION
Upgrade actions/checkout from v1 to v4 in goleaks workflow to resolve workflow failures. Added `fetch-depth: 0` so gitleaks can perform correct scans.

---
*PR created automatically by Jules for task [8124944223235131676](https://jules.google.com/task/8124944223235131676) started by @arran4*