### PR TITLE
docs: explain METHOD: ADD caveats per RFC 5546

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -380,6 +380,21 @@ const (
 	ClassificationConfidential Classification = "CONFIDENTIAL"
 )
 
+// Method represents the iCalendar METHOD property.
+//
+// These should be used with caution when creating simple iCal (.ics) files.
+// The iCalendar specification is defined in RFC 5545. It refers to RFC 5546,
+// which defines the ADD method as allowing the Organizer to add one or more
+// new instances to an existing VEVENT using a single iTIP message. The UID
+// must be that of the existing event.
+//
+// If you include METHOD: ADD in your .ics file (or use SetMethod(MethodAdd)),
+// it is required to refer to existing calendar events. If you are simply
+// writing .ics files to import into calendaring tools, it is not likely that
+// you will want to use this option. Notably, the Apple Calendar program will
+// reject events in .ics files that have this set if they do not refer to
+// existing calendar events; some other calendars (like Microsoft Outlook)
+// have a more permissive import process and will accept them.
 type Method string
 
 const (
@@ -486,6 +501,21 @@ func defaultSerializationOptions() *SerializationConfiguration {
 	return serializeConfig
 }
 
+// SetMethod sets the METHOD property for the calendar.
+//
+// These should be used with caution when creating simple iCal (.ics) files.
+// The iCalendar specification is defined in RFC 5545. It refers to RFC 5546,
+// which defines the ADD method as allowing the Organizer to add one or more
+// new instances to an existing VEVENT using a single iTIP message. The UID
+// must be that of the existing event.
+//
+// If you include METHOD: ADD in your .ics file (or use SetMethod(MethodAdd)),
+// it is required to refer to existing calendar events. If you are simply
+// writing .ics files to import into calendaring tools, it is not likely that
+// you will want to use this option. Notably, the Apple Calendar program will
+// reject events in .ics files that have this set if they do not refer to
+// existing calendar events; some other calendars (like Microsoft Outlook)
+// have a more permissive import process and will accept them.
 func (cal *Calendar) SetMethod(method Method, params ...PropertyParameter) {
 	cal.setProperty(PropertyMethod, string(method), params...)
 }

--- a/calendar.go
+++ b/calendar.go
@@ -385,11 +385,11 @@ const (
 // These should be used with caution when creating simple iCal (.ics) files.
 // The iCalendar specification is defined in RFC 5545. It refers to RFC 5546,
 // which defines the ADD method as allowing the Organizer to add one or more
-// new instances to an existing VEVENT using a single iTIP message. The UID
-// must be that of the existing event.
+// new instances to an existing VEVENT, VTODO, or VJOURNAL using a single iTIP message. The UID
+// must be that of the existing event/task/journal.
 //
 // If you include METHOD: ADD in your .ics file (or use SetMethod(MethodAdd)),
-// it is required to refer to existing calendar events. If you are simply
+// it is required to refer to existing calendar components. If you are simply
 // writing .ics files to import into calendaring tools, it is not likely that
 // you will want to use this option. Notably, the Apple Calendar program will
 // reject events in .ics files that have this set if they do not refer to
@@ -506,11 +506,11 @@ func defaultSerializationOptions() *SerializationConfiguration {
 // These should be used with caution when creating simple iCal (.ics) files.
 // The iCalendar specification is defined in RFC 5545. It refers to RFC 5546,
 // which defines the ADD method as allowing the Organizer to add one or more
-// new instances to an existing VEVENT using a single iTIP message. The UID
-// must be that of the existing event.
+// new instances to an existing VEVENT, VTODO, or VJOURNAL using a single iTIP message. The UID
+// must be that of the existing event/task/journal.
 //
 // If you include METHOD: ADD in your .ics file (or use SetMethod(MethodAdd)),
-// it is required to refer to existing calendar events. If you are simply
+// it is required to refer to existing calendar components. If you are simply
 // writing .ics files to import into calendaring tools, it is not likely that
 // you will want to use this option. Notably, the Apple Calendar program will
 // reject events in .ics files that have this set if they do not refer to


### PR DESCRIPTION
Added documentation to `Method` and `SetMethod` explaining the caveats of using `METHOD: ADD`, specifically its requirement to refer to existing events and strict behavior by clients like Apple Calendar, per issue #120.

---
*PR created automatically by Jules for task [17303485590585798711](https://jules.google.com/task/17303485590585798711) started by @arran4*
--
Resolves https://github.com/arran4/golang-ical/issues/120