### PR TITLE
Add Microsoft iCalendar extensions

### DIFF
--- a/extensions/microsoft/microsoft.go
+++ b/extensions/microsoft/microsoft.go
@@ -4,155 +4,103 @@ import (
 	ical "github.com/arran4/golang-ical"
 )
 
-// PropertyCalend is the X-CALEND property
-const PropertyCalend = "X-CALEND"
+const (
+	// PropertyCalend is the X-CALEND property
+	PropertyCalend ical.Property = "X-CALEND"
+	// PropertyCalstart is the X-CALSTART property
+	PropertyCalstart ical.Property = "X-CALSTART"
+	// PropertyClipend is the X-CLIPEND property
+	PropertyClipend ical.Property = "X-CLIPEND"
+	// PropertyClipstart is the X-CLIPSTART property
+	PropertyClipstart ical.Property = "X-CLIPSTART"
+	// PropertyMicrosoftCalscale is the X-MICROSOFT-CALSCALE property
+	PropertyMicrosoftCalscale ical.Property = "X-MICROSOFT-CALSCALE"
+	// PropertyMsOlkForceinspectoropen is the X-MS-OLK-FORCEINSPECTOROPEN property
+	PropertyMsOlkForceinspectoropen ical.Property = "X-MS-OLK-FORCEINSPECTOROPEN"
+	// PropertyMsWkhrdays is the X-MS-WKHRDAYS property
+	PropertyMsWkhrdays ical.Property = "X-MS-WKHRDAYS"
+	// PropertyMsWkhrend is the X-MS-WKHREND property
+	PropertyMsWkhrend ical.Property = "X-MS-WKHREND"
+	// PropertyMsWkhrstart is the X-MS-WKHRSTART property
+	PropertyMsWkhrstart ical.Property = "X-MS-WKHRSTART"
+	// PropertyOwner is the X-OWNER property
+	PropertyOwner ical.Property = "X-OWNER"
+	// PropertyPrimaryCalendar is the X-PRIMARY-CALENDAR property
+	PropertyPrimaryCalendar ical.Property = "X-PRIMARY-CALENDAR"
+)
 
-// PropertyCalstart is the X-CALSTART property
-const PropertyCalstart = "X-CALSTART"
-
-// PropertyClipend is the X-CLIPEND property
-const PropertyClipend = "X-CLIPEND"
-
-// PropertyClipstart is the X-CLIPSTART property
-const PropertyClipstart = "X-CLIPSTART"
-
-// PropertyMicrosoftCalscale is the X-MICROSOFT-CALSCALE property
-const PropertyMicrosoftCalscale = "X-MICROSOFT-CALSCALE"
-
-// PropertyMsOlkForceinspectoropen is the X-MS-OLK-FORCEINSPECTOROPEN property
-const PropertyMsOlkForceinspectoropen = "X-MS-OLK-FORCEINSPECTOROPEN"
-
-// PropertyMsWkhrdays is the X-MS-WKHRDAYS property
-const PropertyMsWkhrdays = "X-MS-WKHRDAYS"
-
-// PropertyMsWkhrend is the X-MS-WKHREND property
-const PropertyMsWkhrend = "X-MS-WKHREND"
-
-// PropertyMsWkhrstart is the X-MS-WKHRSTART property
-const PropertyMsWkhrstart = "X-MS-WKHRSTART"
-
-// PropertyOwner is the X-OWNER property
-const PropertyOwner = "X-OWNER"
-
-// PropertyPrimaryCalendar is the X-PRIMARY-CALENDAR property
-const PropertyPrimaryCalendar = "X-PRIMARY-CALENDAR"
-
-// PropertyPublishedTtl is the X-PUBLISHED-TTL property
-const PropertyPublishedTtl = "X-PUBLISHED-TTL"
-
-// PropertyCaldesc is the X-WR-CALDESC property
-const PropertyCaldesc = "X-WR-CALDESC"
-
-// PropertyCalname is the X-WR-CALNAME property
-const PropertyCalname = "X-WR-CALNAME"
-
-// PropertyRelcalid is the X-WR-RELCALID property
-const PropertyRelcalid = "X-WR-RELCALID"
-
-// ComponentPropertyAltDesc is the X-ALT-DESC component property
-const ComponentPropertyAltDesc = "X-ALT-DESC"
-
-// ComponentPropertyMicrosoftCdoAlldayevent is the X-MICROSOFT-CDO-ALLDAYEVENT component property
-const ComponentPropertyMicrosoftCdoAlldayevent = "X-MICROSOFT-CDO-ALLDAYEVENT"
-
-// ComponentPropertyMicrosoftCdoApptSequence is the X-MICROSOFT-CDO-APPT-SEQUENCE component property
-const ComponentPropertyMicrosoftCdoApptSequence = "X-MICROSOFT-CDO-APPT-SEQUENCE"
-
-// ComponentPropertyMicrosoftCdoAttendeeCriticalChange is the X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE component property
-const ComponentPropertyMicrosoftCdoAttendeeCriticalChange = "X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE"
-
-// ComponentPropertyMicrosoftCdoBusystatus is the X-MICROSOFT-CDO-BUSYSTATUS component property
-const ComponentPropertyMicrosoftCdoBusystatus = "X-MICROSOFT-CDO-BUSYSTATUS"
-
-// ComponentPropertyMicrosoftCdoImportance is the X-MICROSOFT-CDO-IMPORTANCE component property
-const ComponentPropertyMicrosoftCdoImportance = "X-MICROSOFT-CDO-IMPORTANCE"
-
-// ComponentPropertyMicrosoftCdoInsttype is the X-MICROSOFT-CDO-INSTTYPE component property
-const ComponentPropertyMicrosoftCdoInsttype = "X-MICROSOFT-CDO-INSTTYPE"
-
-// ComponentPropertyMicrosoftCdoIntendedstatus is the X-MICROSOFT-CDO-INTENDEDSTATUS component property
-const ComponentPropertyMicrosoftCdoIntendedstatus = "X-MICROSOFT-CDO-INTENDEDSTATUS"
-
-// ComponentPropertyMicrosoftCdoOwnerapptid is the X-MICROSOFT-CDO-OWNERAPPTID component property
-const ComponentPropertyMicrosoftCdoOwnerapptid = "X-MICROSOFT-CDO-OWNERAPPTID"
-
-// ComponentPropertyMicrosoftCdoOwnerCriticalChange is the X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE component property
-const ComponentPropertyMicrosoftCdoOwnerCriticalChange = "X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE"
-
-// ComponentPropertyMicrosoftCdoReplytime is the X-MICROSOFT-CDO-REPLYTIME component property
-const ComponentPropertyMicrosoftCdoReplytime = "X-MICROSOFT-CDO-REPLYTIME"
-
-// ComponentPropertyMicrosoftDisallowCounter is the X-MICROSOFT-DISALLOW-COUNTER component property
-const ComponentPropertyMicrosoftDisallowCounter = "X-MICROSOFT-DISALLOW-COUNTER"
-
-// ComponentPropertyMicrosoftExdate is the X-MICROSOFT-EXDATE component property
-const ComponentPropertyMicrosoftExdate = "X-MICROSOFT-EXDATE"
-
-// ComponentPropertyMicrosoftIsdraft is the X-MICROSOFT-ISDRAFT component property
-const ComponentPropertyMicrosoftIsdraft = "X-MICROSOFT-ISDRAFT"
-
-// ComponentPropertyMicrosoftMsncalendarAlldayevent is the X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT component property
-const ComponentPropertyMicrosoftMsncalendarAlldayevent = "X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT"
-
-// ComponentPropertyMicrosoftMsncalendarBusystatus is the X-MICROSOFT-MSNCALENDAR-BUSYSTATUS component property
-const ComponentPropertyMicrosoftMsncalendarBusystatus = "X-MICROSOFT-MSNCALENDAR-BUSYSTATUS"
-
-// ComponentPropertyMicrosoftMsncalendarImportance is the X-MICROSOFT-MSNCALENDAR-IMPORTANCE component property
-const ComponentPropertyMicrosoftMsncalendarImportance = "X-MICROSOFT-MSNCALENDAR-IMPORTANCE"
-
-// ComponentPropertyMicrosoftMsncalendarIntendedstatus is the X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS component property
-const ComponentPropertyMicrosoftMsncalendarIntendedstatus = "X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS"
-
-// ComponentPropertyMicrosoftRrule is the X-MICROSOFT-RRULE component property
-const ComponentPropertyMicrosoftRrule = "X-MICROSOFT-RRULE"
-
-// ComponentPropertyMsOlkAllowexterncheck is the X-MS-OLK-ALLOWEXTERNCHECK component property
-const ComponentPropertyMsOlkAllowexterncheck = "X-MS-OLK-ALLOWEXTERNCHECK"
-
-// ComponentPropertyMsOlkApptlastsequence is the X-MS-OLK-APPTLASTSEQUENCE component property
-const ComponentPropertyMsOlkApptlastsequence = "X-MS-OLK-APPTLASTSEQUENCE"
-
-// ComponentPropertyMsOlkApptseqtime is the X-MS-OLK-APPTSEQTIME component property
-const ComponentPropertyMsOlkApptseqtime = "X-MS-OLK-APPTSEQTIME"
-
-// ComponentPropertyMsOlkAutofilllocation is the X-MS-OLK-AUTOFILLLOCATION component property
-const ComponentPropertyMsOlkAutofilllocation = "X-MS-OLK-AUTOFILLLOCATION"
-
-// ComponentPropertyMsOlkAutostartcheck is the X-MS-OLK-AUTOSTARTCHECK component property
-const ComponentPropertyMsOlkAutostartcheck = "X-MS-OLK-AUTOSTARTCHECK"
-
-// ComponentPropertyMsOlkCollaboratedoc is the X-MS-OLK-COLLABORATEDOC component property
-const ComponentPropertyMsOlkCollaboratedoc = "X-MS-OLK-COLLABORATEDOC"
-
-// ComponentPropertyMsOlkConfcheck is the X-MS-OLK-CONFCHECK component property
-const ComponentPropertyMsOlkConfcheck = "X-MS-OLK-CONFCHECK"
-
-// ComponentPropertyMsOlkConftype is the X-MS-OLK-CONFTYPE component property
-const ComponentPropertyMsOlkConftype = "X-MS-OLK-CONFTYPE"
-
-// ComponentPropertyMsOlkDirectory is the X-MS-OLK-DIRECTORY component property
-const ComponentPropertyMsOlkDirectory = "X-MS-OLK-DIRECTORY"
-
-// ComponentPropertyMsOlkMwsurl is the X-MS-OLK-MWSURL component property
-const ComponentPropertyMsOlkMwsurl = "X-MS-OLK-MWSURL"
-
-// ComponentPropertyMsOlkNetshowurl is the X-MS-OLK-NETSHOWURL component property
-const ComponentPropertyMsOlkNetshowurl = "X-MS-OLK-NETSHOWURL"
-
-// ComponentPropertyMsOlkOnlinepassword is the X-MS-OLK-ONLINEPASSWORD component property
-const ComponentPropertyMsOlkOnlinepassword = "X-MS-OLK-ONLINEPASSWORD"
-
-// ComponentPropertyMsOlkOrgalias is the X-MS-OLK-ORGALIAS component property
-const ComponentPropertyMsOlkOrgalias = "X-MS-OLK-ORGALIAS"
-
-// ComponentPropertyMsOlkOriginalend is the X-MS-OLK-ORIGINALEND component property
-const ComponentPropertyMsOlkOriginalend = "X-MS-OLK-ORIGINALEND"
-
-// ComponentPropertyMsOlkOriginalstart is the X-MS-OLK-ORIGINALSTART component property
-const ComponentPropertyMsOlkOriginalstart = "X-MS-OLK-ORIGINALSTART"
-
-// ComponentPropertyMsOlkSender is the X-MS-OLK-SENDER component property
-const ComponentPropertyMsOlkSender = "X-MS-OLK-SENDER"
+const (
+	// ComponentPropertyAltDesc is the X-ALT-DESC component property
+	ComponentPropertyAltDesc ical.ComponentProperty = "X-ALT-DESC"
+	// ComponentPropertyMicrosoftCdoAlldayevent is the X-MICROSOFT-CDO-ALLDAYEVENT component property
+	ComponentPropertyMicrosoftCdoAlldayevent ical.ComponentProperty = "X-MICROSOFT-CDO-ALLDAYEVENT"
+	// ComponentPropertyMicrosoftCdoApptSequence is the X-MICROSOFT-CDO-APPT-SEQUENCE component property
+	ComponentPropertyMicrosoftCdoApptSequence ical.ComponentProperty = "X-MICROSOFT-CDO-APPT-SEQUENCE"
+	// ComponentPropertyMicrosoftCdoAttendeeCriticalChange is the X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE component property
+	ComponentPropertyMicrosoftCdoAttendeeCriticalChange ical.ComponentProperty = "X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE"
+	// ComponentPropertyMicrosoftCdoBusystatus is the X-MICROSOFT-CDO-BUSYSTATUS component property
+	ComponentPropertyMicrosoftCdoBusystatus ical.ComponentProperty = "X-MICROSOFT-CDO-BUSYSTATUS"
+	// ComponentPropertyMicrosoftCdoImportance is the X-MICROSOFT-CDO-IMPORTANCE component property
+	ComponentPropertyMicrosoftCdoImportance ical.ComponentProperty = "X-MICROSOFT-CDO-IMPORTANCE"
+	// ComponentPropertyMicrosoftCdoInsttype is the X-MICROSOFT-CDO-INSTTYPE component property
+	ComponentPropertyMicrosoftCdoInsttype ical.ComponentProperty = "X-MICROSOFT-CDO-INSTTYPE"
+	// ComponentPropertyMicrosoftCdoIntendedstatus is the X-MICROSOFT-CDO-INTENDEDSTATUS component property
+	ComponentPropertyMicrosoftCdoIntendedstatus ical.ComponentProperty = "X-MICROSOFT-CDO-INTENDEDSTATUS"
+	// ComponentPropertyMicrosoftCdoOwnerapptid is the X-MICROSOFT-CDO-OWNERAPPTID component property
+	ComponentPropertyMicrosoftCdoOwnerapptid ical.ComponentProperty = "X-MICROSOFT-CDO-OWNERAPPTID"
+	// ComponentPropertyMicrosoftCdoOwnerCriticalChange is the X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE component property
+	ComponentPropertyMicrosoftCdoOwnerCriticalChange ical.ComponentProperty = "X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE"
+	// ComponentPropertyMicrosoftCdoReplytime is the X-MICROSOFT-CDO-REPLYTIME component property
+	ComponentPropertyMicrosoftCdoReplytime ical.ComponentProperty = "X-MICROSOFT-CDO-REPLYTIME"
+	// ComponentPropertyMicrosoftDisallowCounter is the X-MICROSOFT-DISALLOW-COUNTER component property
+	ComponentPropertyMicrosoftDisallowCounter ical.ComponentProperty = "X-MICROSOFT-DISALLOW-COUNTER"
+	// ComponentPropertyMicrosoftExdate is the X-MICROSOFT-EXDATE component property
+	ComponentPropertyMicrosoftExdate ical.ComponentProperty = "X-MICROSOFT-EXDATE"
+	// ComponentPropertyMicrosoftIsdraft is the X-MICROSOFT-ISDRAFT component property
+	ComponentPropertyMicrosoftIsdraft ical.ComponentProperty = "X-MICROSOFT-ISDRAFT"
+	// ComponentPropertyMicrosoftMsncalendarAlldayevent is the X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT component property
+	ComponentPropertyMicrosoftMsncalendarAlldayevent ical.ComponentProperty = "X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT"
+	// ComponentPropertyMicrosoftMsncalendarBusystatus is the X-MICROSOFT-MSNCALENDAR-BUSYSTATUS component property
+	ComponentPropertyMicrosoftMsncalendarBusystatus ical.ComponentProperty = "X-MICROSOFT-MSNCALENDAR-BUSYSTATUS"
+	// ComponentPropertyMicrosoftMsncalendarImportance is the X-MICROSOFT-MSNCALENDAR-IMPORTANCE component property
+	ComponentPropertyMicrosoftMsncalendarImportance ical.ComponentProperty = "X-MICROSOFT-MSNCALENDAR-IMPORTANCE"
+	// ComponentPropertyMicrosoftMsncalendarIntendedstatus is the X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS component property
+	ComponentPropertyMicrosoftMsncalendarIntendedstatus ical.ComponentProperty = "X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS"
+	// ComponentPropertyMicrosoftRrule is the X-MICROSOFT-RRULE component property
+	ComponentPropertyMicrosoftRrule ical.ComponentProperty = "X-MICROSOFT-RRULE"
+	// ComponentPropertyMsOlkAllowexterncheck is the X-MS-OLK-ALLOWEXTERNCHECK component property
+	ComponentPropertyMsOlkAllowexterncheck ical.ComponentProperty = "X-MS-OLK-ALLOWEXTERNCHECK"
+	// ComponentPropertyMsOlkApptlastsequence is the X-MS-OLK-APPTLASTSEQUENCE component property
+	ComponentPropertyMsOlkApptlastsequence ical.ComponentProperty = "X-MS-OLK-APPTLASTSEQUENCE"
+	// ComponentPropertyMsOlkApptseqtime is the X-MS-OLK-APPTSEQTIME component property
+	ComponentPropertyMsOlkApptseqtime ical.ComponentProperty = "X-MS-OLK-APPTSEQTIME"
+	// ComponentPropertyMsOlkAutofilllocation is the X-MS-OLK-AUTOFILLLOCATION component property
+	ComponentPropertyMsOlkAutofilllocation ical.ComponentProperty = "X-MS-OLK-AUTOFILLLOCATION"
+	// ComponentPropertyMsOlkAutostartcheck is the X-MS-OLK-AUTOSTARTCHECK component property
+	ComponentPropertyMsOlkAutostartcheck ical.ComponentProperty = "X-MS-OLK-AUTOSTARTCHECK"
+	// ComponentPropertyMsOlkCollaboratedoc is the X-MS-OLK-COLLABORATEDOC component property
+	ComponentPropertyMsOlkCollaboratedoc ical.ComponentProperty = "X-MS-OLK-COLLABORATEDOC"
+	// ComponentPropertyMsOlkConfcheck is the X-MS-OLK-CONFCHECK component property
+	ComponentPropertyMsOlkConfcheck ical.ComponentProperty = "X-MS-OLK-CONFCHECK"
+	// ComponentPropertyMsOlkConftype is the X-MS-OLK-CONFTYPE component property
+	ComponentPropertyMsOlkConftype ical.ComponentProperty = "X-MS-OLK-CONFTYPE"
+	// ComponentPropertyMsOlkDirectory is the X-MS-OLK-DIRECTORY component property
+	ComponentPropertyMsOlkDirectory ical.ComponentProperty = "X-MS-OLK-DIRECTORY"
+	// ComponentPropertyMsOlkMwsurl is the X-MS-OLK-MWSURL component property
+	ComponentPropertyMsOlkMwsurl ical.ComponentProperty = "X-MS-OLK-MWSURL"
+	// ComponentPropertyMsOlkNetshowurl is the X-MS-OLK-NETSHOWURL component property
+	ComponentPropertyMsOlkNetshowurl ical.ComponentProperty = "X-MS-OLK-NETSHOWURL"
+	// ComponentPropertyMsOlkOnlinepassword is the X-MS-OLK-ONLINEPASSWORD component property
+	ComponentPropertyMsOlkOnlinepassword ical.ComponentProperty = "X-MS-OLK-ONLINEPASSWORD"
+	// ComponentPropertyMsOlkOrgalias is the X-MS-OLK-ORGALIAS component property
+	ComponentPropertyMsOlkOrgalias ical.ComponentProperty = "X-MS-OLK-ORGALIAS"
+	// ComponentPropertyMsOlkOriginalend is the X-MS-OLK-ORIGINALEND component property
+	ComponentPropertyMsOlkOriginalend ical.ComponentProperty = "X-MS-OLK-ORIGINALEND"
+	// ComponentPropertyMsOlkOriginalstart is the X-MS-OLK-ORIGINALSTART component property
+	ComponentPropertyMsOlkOriginalstart ical.ComponentProperty = "X-MS-OLK-ORIGINALSTART"
+	// ComponentPropertyMsOlkSender is the X-MS-OLK-SENDER component property
+	ComponentPropertyMsOlkSender ical.ComponentProperty = "X-MS-OLK-SENDER"
+)
 
 type propertySetter interface {
 	SetProperty(property ical.ComponentProperty, value string, props ...ical.PropertyParameter)
@@ -205,251 +153,231 @@ func SetComponentProperty(c ical.Component, property string, value string, param
 // Calendar properties
 // SetCalend sets the X-CALEND property for the calendar
 func SetCalend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyCalend, value, params...)
+	SetProperty(cal, string(PropertyCalend), value, params...)
 }
 
 // SetCalstart sets the X-CALSTART property for the calendar
 func SetCalstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyCalstart, value, params...)
+	SetProperty(cal, string(PropertyCalstart), value, params...)
 }
 
 // SetClipend sets the X-CLIPEND property for the calendar
 func SetClipend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyClipend, value, params...)
+	SetProperty(cal, string(PropertyClipend), value, params...)
 }
 
 // SetClipstart sets the X-CLIPSTART property for the calendar
 func SetClipstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyClipstart, value, params...)
+	SetProperty(cal, string(PropertyClipstart), value, params...)
 }
 
 // SetMicrosoftCalscale sets the X-MICROSOFT-CALSCALE property for the calendar
 func SetMicrosoftCalscale(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyMicrosoftCalscale, value, params...)
+	SetProperty(cal, string(PropertyMicrosoftCalscale), value, params...)
 }
 
 // SetMsOlkForceinspectoropen sets the X-MS-OLK-FORCEINSPECTOROPEN property for the calendar
 func SetMsOlkForceinspectoropen(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyMsOlkForceinspectoropen, value, params...)
+	SetProperty(cal, string(PropertyMsOlkForceinspectoropen), value, params...)
 }
 
 // SetMsWkhrdays sets the X-MS-WKHRDAYS property for the calendar
 func SetMsWkhrdays(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyMsWkhrdays, value, params...)
+	SetProperty(cal, string(PropertyMsWkhrdays), value, params...)
 }
 
 // SetMsWkhrend sets the X-MS-WKHREND property for the calendar
 func SetMsWkhrend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyMsWkhrend, value, params...)
+	SetProperty(cal, string(PropertyMsWkhrend), value, params...)
 }
 
 // SetMsWkhrstart sets the X-MS-WKHRSTART property for the calendar
 func SetMsWkhrstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyMsWkhrstart, value, params...)
+	SetProperty(cal, string(PropertyMsWkhrstart), value, params...)
 }
 
 // SetOwner sets the X-OWNER property for the calendar
 func SetOwner(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyOwner, value, params...)
+	SetProperty(cal, string(PropertyOwner), value, params...)
 }
 
 // SetPrimaryCalendar sets the X-PRIMARY-CALENDAR property for the calendar
 func SetPrimaryCalendar(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyPrimaryCalendar, value, params...)
-}
-
-// SetPublishedTtl sets the X-PUBLISHED-TTL property for the calendar
-func SetPublishedTtl(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyPublishedTtl, value, params...)
-}
-
-// SetCaldesc sets the X-WR-CALDESC property for the calendar
-func SetCaldesc(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyCaldesc, value, params...)
-}
-
-// SetCalname sets the X-WR-CALNAME property for the calendar
-func SetCalname(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyCalname, value, params...)
-}
-
-// SetRelcalid sets the X-WR-RELCALID property for the calendar
-func SetRelcalid(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyRelcalid, value, params...)
+	SetProperty(cal, string(PropertyPrimaryCalendar), value, params...)
 }
 
 // Component properties
 // SetAltDesc sets the X-ALT-DESC property for a component
 func SetAltDesc(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyAltDesc, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyAltDesc), value, params...)
 }
 
 // SetMicrosoftCdoAlldayevent sets the X-MICROSOFT-CDO-ALLDAYEVENT property for a component
 func SetMicrosoftCdoAlldayevent(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoAlldayevent, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoAlldayevent), value, params...)
 }
 
 // SetMicrosoftCdoApptSequence sets the X-MICROSOFT-CDO-APPT-SEQUENCE property for a component
 func SetMicrosoftCdoApptSequence(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoApptSequence, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoApptSequence), value, params...)
 }
 
 // SetMicrosoftCdoAttendeeCriticalChange sets the X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE property for a component
 func SetMicrosoftCdoAttendeeCriticalChange(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoAttendeeCriticalChange, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoAttendeeCriticalChange), value, params...)
 }
 
 // SetMicrosoftCdoBusystatus sets the X-MICROSOFT-CDO-BUSYSTATUS property for a component
 func SetMicrosoftCdoBusystatus(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoBusystatus, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoBusystatus), value, params...)
 }
 
 // SetMicrosoftCdoImportance sets the X-MICROSOFT-CDO-IMPORTANCE property for a component
 func SetMicrosoftCdoImportance(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoImportance, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoImportance), value, params...)
 }
 
 // SetMicrosoftCdoInsttype sets the X-MICROSOFT-CDO-INSTTYPE property for a component
 func SetMicrosoftCdoInsttype(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoInsttype, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoInsttype), value, params...)
 }
 
 // SetMicrosoftCdoIntendedstatus sets the X-MICROSOFT-CDO-INTENDEDSTATUS property for a component
 func SetMicrosoftCdoIntendedstatus(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoIntendedstatus, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoIntendedstatus), value, params...)
 }
 
 // SetMicrosoftCdoOwnerapptid sets the X-MICROSOFT-CDO-OWNERAPPTID property for a component
 func SetMicrosoftCdoOwnerapptid(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoOwnerapptid, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoOwnerapptid), value, params...)
 }
 
 // SetMicrosoftCdoOwnerCriticalChange sets the X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE property for a component
 func SetMicrosoftCdoOwnerCriticalChange(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoOwnerCriticalChange, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoOwnerCriticalChange), value, params...)
 }
 
 // SetMicrosoftCdoReplytime sets the X-MICROSOFT-CDO-REPLYTIME property for a component
 func SetMicrosoftCdoReplytime(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftCdoReplytime, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftCdoReplytime), value, params...)
 }
 
 // SetMicrosoftDisallowCounter sets the X-MICROSOFT-DISALLOW-COUNTER property for a component
 func SetMicrosoftDisallowCounter(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftDisallowCounter, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftDisallowCounter), value, params...)
 }
 
 // SetMicrosoftExdate sets the X-MICROSOFT-EXDATE property for a component
 func SetMicrosoftExdate(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftExdate, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftExdate), value, params...)
 }
 
 // SetMicrosoftIsdraft sets the X-MICROSOFT-ISDRAFT property for a component
 func SetMicrosoftIsdraft(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftIsdraft, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftIsdraft), value, params...)
 }
 
 // SetMicrosoftMsncalendarAlldayevent sets the X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT property for a component
 func SetMicrosoftMsncalendarAlldayevent(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarAlldayevent, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftMsncalendarAlldayevent), value, params...)
 }
 
 // SetMicrosoftMsncalendarBusystatus sets the X-MICROSOFT-MSNCALENDAR-BUSYSTATUS property for a component
 func SetMicrosoftMsncalendarBusystatus(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarBusystatus, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftMsncalendarBusystatus), value, params...)
 }
 
 // SetMicrosoftMsncalendarImportance sets the X-MICROSOFT-MSNCALENDAR-IMPORTANCE property for a component
 func SetMicrosoftMsncalendarImportance(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarImportance, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftMsncalendarImportance), value, params...)
 }
 
 // SetMicrosoftMsncalendarIntendedstatus sets the X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS property for a component
 func SetMicrosoftMsncalendarIntendedstatus(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarIntendedstatus, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftMsncalendarIntendedstatus), value, params...)
 }
 
 // SetMicrosoftRrule sets the X-MICROSOFT-RRULE property for a component
 func SetMicrosoftRrule(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMicrosoftRrule, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMicrosoftRrule), value, params...)
 }
 
 // SetMsOlkAllowexterncheck sets the X-MS-OLK-ALLOWEXTERNCHECK property for a component
 func SetMsOlkAllowexterncheck(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkAllowexterncheck, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkAllowexterncheck), value, params...)
 }
 
 // SetMsOlkApptlastsequence sets the X-MS-OLK-APPTLASTSEQUENCE property for a component
 func SetMsOlkApptlastsequence(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkApptlastsequence, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkApptlastsequence), value, params...)
 }
 
 // SetMsOlkApptseqtime sets the X-MS-OLK-APPTSEQTIME property for a component
 func SetMsOlkApptseqtime(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkApptseqtime, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkApptseqtime), value, params...)
 }
 
 // SetMsOlkAutofilllocation sets the X-MS-OLK-AUTOFILLLOCATION property for a component
 func SetMsOlkAutofilllocation(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkAutofilllocation, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkAutofilllocation), value, params...)
 }
 
 // SetMsOlkAutostartcheck sets the X-MS-OLK-AUTOSTARTCHECK property for a component
 func SetMsOlkAutostartcheck(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkAutostartcheck, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkAutostartcheck), value, params...)
 }
 
 // SetMsOlkCollaboratedoc sets the X-MS-OLK-COLLABORATEDOC property for a component
 func SetMsOlkCollaboratedoc(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkCollaboratedoc, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkCollaboratedoc), value, params...)
 }
 
 // SetMsOlkConfcheck sets the X-MS-OLK-CONFCHECK property for a component
 func SetMsOlkConfcheck(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkConfcheck, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkConfcheck), value, params...)
 }
 
 // SetMsOlkConftype sets the X-MS-OLK-CONFTYPE property for a component
 func SetMsOlkConftype(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkConftype, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkConftype), value, params...)
 }
 
 // SetMsOlkDirectory sets the X-MS-OLK-DIRECTORY property for a component
 func SetMsOlkDirectory(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkDirectory, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkDirectory), value, params...)
 }
 
 // SetMsOlkMwsurl sets the X-MS-OLK-MWSURL property for a component
 func SetMsOlkMwsurl(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkMwsurl, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkMwsurl), value, params...)
 }
 
 // SetMsOlkNetshowurl sets the X-MS-OLK-NETSHOWURL property for a component
 func SetMsOlkNetshowurl(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkNetshowurl, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkNetshowurl), value, params...)
 }
 
 // SetMsOlkOnlinepassword sets the X-MS-OLK-ONLINEPASSWORD property for a component
 func SetMsOlkOnlinepassword(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkOnlinepassword, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkOnlinepassword), value, params...)
 }
 
 // SetMsOlkOrgalias sets the X-MS-OLK-ORGALIAS property for a component
 func SetMsOlkOrgalias(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkOrgalias, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkOrgalias), value, params...)
 }
 
 // SetMsOlkOriginalend sets the X-MS-OLK-ORIGINALEND property for a component
 func SetMsOlkOriginalend(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkOriginalend, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkOriginalend), value, params...)
 }
 
 // SetMsOlkOriginalstart sets the X-MS-OLK-ORIGINALSTART property for a component
 func SetMsOlkOriginalstart(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkOriginalstart, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkOriginalstart), value, params...)
 }
 
 // SetMsOlkSender sets the X-MS-OLK-SENDER property for a component
 func SetMsOlkSender(c ical.Component, value string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyMsOlkSender, value, params...)
+	SetComponentProperty(c, string(ComponentPropertyMsOlkSender), value, params...)
 }

--- a/extensions/microsoft/microsoft.go
+++ b/extensions/microsoft/microsoft.go
@@ -1,0 +1,455 @@
+package microsoft
+
+import (
+	ical "github.com/arran4/golang-ical"
+)
+
+// PropertyCalend is the X-CALEND property
+const PropertyCalend = "X-CALEND"
+
+// PropertyCalstart is the X-CALSTART property
+const PropertyCalstart = "X-CALSTART"
+
+// PropertyClipend is the X-CLIPEND property
+const PropertyClipend = "X-CLIPEND"
+
+// PropertyClipstart is the X-CLIPSTART property
+const PropertyClipstart = "X-CLIPSTART"
+
+// PropertyMicrosoftCalscale is the X-MICROSOFT-CALSCALE property
+const PropertyMicrosoftCalscale = "X-MICROSOFT-CALSCALE"
+
+// PropertyMsOlkForceinspectoropen is the X-MS-OLK-FORCEINSPECTOROPEN property
+const PropertyMsOlkForceinspectoropen = "X-MS-OLK-FORCEINSPECTOROPEN"
+
+// PropertyMsWkhrdays is the X-MS-WKHRDAYS property
+const PropertyMsWkhrdays = "X-MS-WKHRDAYS"
+
+// PropertyMsWkhrend is the X-MS-WKHREND property
+const PropertyMsWkhrend = "X-MS-WKHREND"
+
+// PropertyMsWkhrstart is the X-MS-WKHRSTART property
+const PropertyMsWkhrstart = "X-MS-WKHRSTART"
+
+// PropertyOwner is the X-OWNER property
+const PropertyOwner = "X-OWNER"
+
+// PropertyPrimaryCalendar is the X-PRIMARY-CALENDAR property
+const PropertyPrimaryCalendar = "X-PRIMARY-CALENDAR"
+
+// PropertyPublishedTtl is the X-PUBLISHED-TTL property
+const PropertyPublishedTtl = "X-PUBLISHED-TTL"
+
+// PropertyCaldesc is the X-WR-CALDESC property
+const PropertyCaldesc = "X-WR-CALDESC"
+
+// PropertyCalname is the X-WR-CALNAME property
+const PropertyCalname = "X-WR-CALNAME"
+
+// PropertyRelcalid is the X-WR-RELCALID property
+const PropertyRelcalid = "X-WR-RELCALID"
+
+// ComponentPropertyAltDesc is the X-ALT-DESC component property
+const ComponentPropertyAltDesc = "X-ALT-DESC"
+
+// ComponentPropertyMicrosoftCdoAlldayevent is the X-MICROSOFT-CDO-ALLDAYEVENT component property
+const ComponentPropertyMicrosoftCdoAlldayevent = "X-MICROSOFT-CDO-ALLDAYEVENT"
+
+// ComponentPropertyMicrosoftCdoApptSequence is the X-MICROSOFT-CDO-APPT-SEQUENCE component property
+const ComponentPropertyMicrosoftCdoApptSequence = "X-MICROSOFT-CDO-APPT-SEQUENCE"
+
+// ComponentPropertyMicrosoftCdoAttendeeCriticalChange is the X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE component property
+const ComponentPropertyMicrosoftCdoAttendeeCriticalChange = "X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE"
+
+// ComponentPropertyMicrosoftCdoBusystatus is the X-MICROSOFT-CDO-BUSYSTATUS component property
+const ComponentPropertyMicrosoftCdoBusystatus = "X-MICROSOFT-CDO-BUSYSTATUS"
+
+// ComponentPropertyMicrosoftCdoImportance is the X-MICROSOFT-CDO-IMPORTANCE component property
+const ComponentPropertyMicrosoftCdoImportance = "X-MICROSOFT-CDO-IMPORTANCE"
+
+// ComponentPropertyMicrosoftCdoInsttype is the X-MICROSOFT-CDO-INSTTYPE component property
+const ComponentPropertyMicrosoftCdoInsttype = "X-MICROSOFT-CDO-INSTTYPE"
+
+// ComponentPropertyMicrosoftCdoIntendedstatus is the X-MICROSOFT-CDO-INTENDEDSTATUS component property
+const ComponentPropertyMicrosoftCdoIntendedstatus = "X-MICROSOFT-CDO-INTENDEDSTATUS"
+
+// ComponentPropertyMicrosoftCdoOwnerapptid is the X-MICROSOFT-CDO-OWNERAPPTID component property
+const ComponentPropertyMicrosoftCdoOwnerapptid = "X-MICROSOFT-CDO-OWNERAPPTID"
+
+// ComponentPropertyMicrosoftCdoOwnerCriticalChange is the X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE component property
+const ComponentPropertyMicrosoftCdoOwnerCriticalChange = "X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE"
+
+// ComponentPropertyMicrosoftCdoReplytime is the X-MICROSOFT-CDO-REPLYTIME component property
+const ComponentPropertyMicrosoftCdoReplytime = "X-MICROSOFT-CDO-REPLYTIME"
+
+// ComponentPropertyMicrosoftDisallowCounter is the X-MICROSOFT-DISALLOW-COUNTER component property
+const ComponentPropertyMicrosoftDisallowCounter = "X-MICROSOFT-DISALLOW-COUNTER"
+
+// ComponentPropertyMicrosoftExdate is the X-MICROSOFT-EXDATE component property
+const ComponentPropertyMicrosoftExdate = "X-MICROSOFT-EXDATE"
+
+// ComponentPropertyMicrosoftIsdraft is the X-MICROSOFT-ISDRAFT component property
+const ComponentPropertyMicrosoftIsdraft = "X-MICROSOFT-ISDRAFT"
+
+// ComponentPropertyMicrosoftMsncalendarAlldayevent is the X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT component property
+const ComponentPropertyMicrosoftMsncalendarAlldayevent = "X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT"
+
+// ComponentPropertyMicrosoftMsncalendarBusystatus is the X-MICROSOFT-MSNCALENDAR-BUSYSTATUS component property
+const ComponentPropertyMicrosoftMsncalendarBusystatus = "X-MICROSOFT-MSNCALENDAR-BUSYSTATUS"
+
+// ComponentPropertyMicrosoftMsncalendarImportance is the X-MICROSOFT-MSNCALENDAR-IMPORTANCE component property
+const ComponentPropertyMicrosoftMsncalendarImportance = "X-MICROSOFT-MSNCALENDAR-IMPORTANCE"
+
+// ComponentPropertyMicrosoftMsncalendarIntendedstatus is the X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS component property
+const ComponentPropertyMicrosoftMsncalendarIntendedstatus = "X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS"
+
+// ComponentPropertyMicrosoftRrule is the X-MICROSOFT-RRULE component property
+const ComponentPropertyMicrosoftRrule = "X-MICROSOFT-RRULE"
+
+// ComponentPropertyMsOlkAllowexterncheck is the X-MS-OLK-ALLOWEXTERNCHECK component property
+const ComponentPropertyMsOlkAllowexterncheck = "X-MS-OLK-ALLOWEXTERNCHECK"
+
+// ComponentPropertyMsOlkApptlastsequence is the X-MS-OLK-APPTLASTSEQUENCE component property
+const ComponentPropertyMsOlkApptlastsequence = "X-MS-OLK-APPTLASTSEQUENCE"
+
+// ComponentPropertyMsOlkApptseqtime is the X-MS-OLK-APPTSEQTIME component property
+const ComponentPropertyMsOlkApptseqtime = "X-MS-OLK-APPTSEQTIME"
+
+// ComponentPropertyMsOlkAutofilllocation is the X-MS-OLK-AUTOFILLLOCATION component property
+const ComponentPropertyMsOlkAutofilllocation = "X-MS-OLK-AUTOFILLLOCATION"
+
+// ComponentPropertyMsOlkAutostartcheck is the X-MS-OLK-AUTOSTARTCHECK component property
+const ComponentPropertyMsOlkAutostartcheck = "X-MS-OLK-AUTOSTARTCHECK"
+
+// ComponentPropertyMsOlkCollaboratedoc is the X-MS-OLK-COLLABORATEDOC component property
+const ComponentPropertyMsOlkCollaboratedoc = "X-MS-OLK-COLLABORATEDOC"
+
+// ComponentPropertyMsOlkConfcheck is the X-MS-OLK-CONFCHECK component property
+const ComponentPropertyMsOlkConfcheck = "X-MS-OLK-CONFCHECK"
+
+// ComponentPropertyMsOlkConftype is the X-MS-OLK-CONFTYPE component property
+const ComponentPropertyMsOlkConftype = "X-MS-OLK-CONFTYPE"
+
+// ComponentPropertyMsOlkDirectory is the X-MS-OLK-DIRECTORY component property
+const ComponentPropertyMsOlkDirectory = "X-MS-OLK-DIRECTORY"
+
+// ComponentPropertyMsOlkMwsurl is the X-MS-OLK-MWSURL component property
+const ComponentPropertyMsOlkMwsurl = "X-MS-OLK-MWSURL"
+
+// ComponentPropertyMsOlkNetshowurl is the X-MS-OLK-NETSHOWURL component property
+const ComponentPropertyMsOlkNetshowurl = "X-MS-OLK-NETSHOWURL"
+
+// ComponentPropertyMsOlkOnlinepassword is the X-MS-OLK-ONLINEPASSWORD component property
+const ComponentPropertyMsOlkOnlinepassword = "X-MS-OLK-ONLINEPASSWORD"
+
+// ComponentPropertyMsOlkOrgalias is the X-MS-OLK-ORGALIAS component property
+const ComponentPropertyMsOlkOrgalias = "X-MS-OLK-ORGALIAS"
+
+// ComponentPropertyMsOlkOriginalend is the X-MS-OLK-ORIGINALEND component property
+const ComponentPropertyMsOlkOriginalend = "X-MS-OLK-ORIGINALEND"
+
+// ComponentPropertyMsOlkOriginalstart is the X-MS-OLK-ORIGINALSTART component property
+const ComponentPropertyMsOlkOriginalstart = "X-MS-OLK-ORIGINALSTART"
+
+// ComponentPropertyMsOlkSender is the X-MS-OLK-SENDER component property
+const ComponentPropertyMsOlkSender = "X-MS-OLK-SENDER"
+
+type propertySetter interface {
+	SetProperty(property ical.ComponentProperty, value string, props ...ical.PropertyParameter)
+}
+
+// SetProperty allows extending the properties easily
+func SetProperty(cal *ical.Calendar, property string, value string, params ...ical.PropertyParameter) {
+	if cal == nil {
+		return
+	}
+	// Fallback to directly modify CalendarProperties if no public SetProperty exists
+	found := false
+	for i := range cal.CalendarProperties {
+		if cal.CalendarProperties[i].IANAToken == property {
+			cal.CalendarProperties[i].Value = value
+			cal.CalendarProperties[i].ICalParameters = map[string][]string{}
+			for _, p := range params {
+				k, v := p.KeyValue()
+				cal.CalendarProperties[i].ICalParameters[k] = v
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		r := ical.CalendarProperty{
+			BaseProperty: ical.BaseProperty{
+				IANAToken:      property,
+				Value:          value,
+				ICalParameters: map[string][]string{},
+			},
+		}
+		for _, p := range params {
+			k, v := p.KeyValue()
+			r.ICalParameters[k] = v
+		}
+		cal.CalendarProperties = append(cal.CalendarProperties, r)
+	}
+}
+
+func SetComponentProperty(c ical.Component, property string, value string, params ...ical.PropertyParameter) {
+	if c == nil {
+		return
+	}
+	if ps, ok := c.(propertySetter); ok {
+		ps.SetProperty(ical.ComponentProperty(property), value, params...)
+	}
+}
+
+// Calendar properties
+// SetCalend sets the X-CALEND property for the calendar
+func SetCalend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyCalend, value, params...)
+}
+
+// SetCalstart sets the X-CALSTART property for the calendar
+func SetCalstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyCalstart, value, params...)
+}
+
+// SetClipend sets the X-CLIPEND property for the calendar
+func SetClipend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyClipend, value, params...)
+}
+
+// SetClipstart sets the X-CLIPSTART property for the calendar
+func SetClipstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyClipstart, value, params...)
+}
+
+// SetMicrosoftCalscale sets the X-MICROSOFT-CALSCALE property for the calendar
+func SetMicrosoftCalscale(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyMicrosoftCalscale, value, params...)
+}
+
+// SetMsOlkForceinspectoropen sets the X-MS-OLK-FORCEINSPECTOROPEN property for the calendar
+func SetMsOlkForceinspectoropen(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyMsOlkForceinspectoropen, value, params...)
+}
+
+// SetMsWkhrdays sets the X-MS-WKHRDAYS property for the calendar
+func SetMsWkhrdays(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyMsWkhrdays, value, params...)
+}
+
+// SetMsWkhrend sets the X-MS-WKHREND property for the calendar
+func SetMsWkhrend(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyMsWkhrend, value, params...)
+}
+
+// SetMsWkhrstart sets the X-MS-WKHRSTART property for the calendar
+func SetMsWkhrstart(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyMsWkhrstart, value, params...)
+}
+
+// SetOwner sets the X-OWNER property for the calendar
+func SetOwner(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyOwner, value, params...)
+}
+
+// SetPrimaryCalendar sets the X-PRIMARY-CALENDAR property for the calendar
+func SetPrimaryCalendar(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyPrimaryCalendar, value, params...)
+}
+
+// SetPublishedTtl sets the X-PUBLISHED-TTL property for the calendar
+func SetPublishedTtl(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyPublishedTtl, value, params...)
+}
+
+// SetCaldesc sets the X-WR-CALDESC property for the calendar
+func SetCaldesc(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyCaldesc, value, params...)
+}
+
+// SetCalname sets the X-WR-CALNAME property for the calendar
+func SetCalname(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyCalname, value, params...)
+}
+
+// SetRelcalid sets the X-WR-RELCALID property for the calendar
+func SetRelcalid(cal *ical.Calendar, value string, params ...ical.PropertyParameter) {
+	SetProperty(cal, PropertyRelcalid, value, params...)
+}
+
+// Component properties
+// SetAltDesc sets the X-ALT-DESC property for a component
+func SetAltDesc(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyAltDesc, value, params...)
+}
+
+// SetMicrosoftCdoAlldayevent sets the X-MICROSOFT-CDO-ALLDAYEVENT property for a component
+func SetMicrosoftCdoAlldayevent(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoAlldayevent, value, params...)
+}
+
+// SetMicrosoftCdoApptSequence sets the X-MICROSOFT-CDO-APPT-SEQUENCE property for a component
+func SetMicrosoftCdoApptSequence(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoApptSequence, value, params...)
+}
+
+// SetMicrosoftCdoAttendeeCriticalChange sets the X-MICROSOFT-CDO-ATTENDEE-CRITICAL-CHANGE property for a component
+func SetMicrosoftCdoAttendeeCriticalChange(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoAttendeeCriticalChange, value, params...)
+}
+
+// SetMicrosoftCdoBusystatus sets the X-MICROSOFT-CDO-BUSYSTATUS property for a component
+func SetMicrosoftCdoBusystatus(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoBusystatus, value, params...)
+}
+
+// SetMicrosoftCdoImportance sets the X-MICROSOFT-CDO-IMPORTANCE property for a component
+func SetMicrosoftCdoImportance(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoImportance, value, params...)
+}
+
+// SetMicrosoftCdoInsttype sets the X-MICROSOFT-CDO-INSTTYPE property for a component
+func SetMicrosoftCdoInsttype(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoInsttype, value, params...)
+}
+
+// SetMicrosoftCdoIntendedstatus sets the X-MICROSOFT-CDO-INTENDEDSTATUS property for a component
+func SetMicrosoftCdoIntendedstatus(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoIntendedstatus, value, params...)
+}
+
+// SetMicrosoftCdoOwnerapptid sets the X-MICROSOFT-CDO-OWNERAPPTID property for a component
+func SetMicrosoftCdoOwnerapptid(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoOwnerapptid, value, params...)
+}
+
+// SetMicrosoftCdoOwnerCriticalChange sets the X-MICROSOFT-CDO-OWNER-CRITICAL-CHANGE property for a component
+func SetMicrosoftCdoOwnerCriticalChange(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoOwnerCriticalChange, value, params...)
+}
+
+// SetMicrosoftCdoReplytime sets the X-MICROSOFT-CDO-REPLYTIME property for a component
+func SetMicrosoftCdoReplytime(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftCdoReplytime, value, params...)
+}
+
+// SetMicrosoftDisallowCounter sets the X-MICROSOFT-DISALLOW-COUNTER property for a component
+func SetMicrosoftDisallowCounter(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftDisallowCounter, value, params...)
+}
+
+// SetMicrosoftExdate sets the X-MICROSOFT-EXDATE property for a component
+func SetMicrosoftExdate(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftExdate, value, params...)
+}
+
+// SetMicrosoftIsdraft sets the X-MICROSOFT-ISDRAFT property for a component
+func SetMicrosoftIsdraft(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftIsdraft, value, params...)
+}
+
+// SetMicrosoftMsncalendarAlldayevent sets the X-MICROSOFT-MSNCALENDAR-ALLDAYEVENT property for a component
+func SetMicrosoftMsncalendarAlldayevent(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarAlldayevent, value, params...)
+}
+
+// SetMicrosoftMsncalendarBusystatus sets the X-MICROSOFT-MSNCALENDAR-BUSYSTATUS property for a component
+func SetMicrosoftMsncalendarBusystatus(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarBusystatus, value, params...)
+}
+
+// SetMicrosoftMsncalendarImportance sets the X-MICROSOFT-MSNCALENDAR-IMPORTANCE property for a component
+func SetMicrosoftMsncalendarImportance(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarImportance, value, params...)
+}
+
+// SetMicrosoftMsncalendarIntendedstatus sets the X-MICROSOFT-MSNCALENDAR-INTENDEDSTATUS property for a component
+func SetMicrosoftMsncalendarIntendedstatus(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftMsncalendarIntendedstatus, value, params...)
+}
+
+// SetMicrosoftRrule sets the X-MICROSOFT-RRULE property for a component
+func SetMicrosoftRrule(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMicrosoftRrule, value, params...)
+}
+
+// SetMsOlkAllowexterncheck sets the X-MS-OLK-ALLOWEXTERNCHECK property for a component
+func SetMsOlkAllowexterncheck(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkAllowexterncheck, value, params...)
+}
+
+// SetMsOlkApptlastsequence sets the X-MS-OLK-APPTLASTSEQUENCE property for a component
+func SetMsOlkApptlastsequence(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkApptlastsequence, value, params...)
+}
+
+// SetMsOlkApptseqtime sets the X-MS-OLK-APPTSEQTIME property for a component
+func SetMsOlkApptseqtime(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkApptseqtime, value, params...)
+}
+
+// SetMsOlkAutofilllocation sets the X-MS-OLK-AUTOFILLLOCATION property for a component
+func SetMsOlkAutofilllocation(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkAutofilllocation, value, params...)
+}
+
+// SetMsOlkAutostartcheck sets the X-MS-OLK-AUTOSTARTCHECK property for a component
+func SetMsOlkAutostartcheck(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkAutostartcheck, value, params...)
+}
+
+// SetMsOlkCollaboratedoc sets the X-MS-OLK-COLLABORATEDOC property for a component
+func SetMsOlkCollaboratedoc(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkCollaboratedoc, value, params...)
+}
+
+// SetMsOlkConfcheck sets the X-MS-OLK-CONFCHECK property for a component
+func SetMsOlkConfcheck(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkConfcheck, value, params...)
+}
+
+// SetMsOlkConftype sets the X-MS-OLK-CONFTYPE property for a component
+func SetMsOlkConftype(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkConftype, value, params...)
+}
+
+// SetMsOlkDirectory sets the X-MS-OLK-DIRECTORY property for a component
+func SetMsOlkDirectory(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkDirectory, value, params...)
+}
+
+// SetMsOlkMwsurl sets the X-MS-OLK-MWSURL property for a component
+func SetMsOlkMwsurl(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkMwsurl, value, params...)
+}
+
+// SetMsOlkNetshowurl sets the X-MS-OLK-NETSHOWURL property for a component
+func SetMsOlkNetshowurl(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkNetshowurl, value, params...)
+}
+
+// SetMsOlkOnlinepassword sets the X-MS-OLK-ONLINEPASSWORD property for a component
+func SetMsOlkOnlinepassword(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkOnlinepassword, value, params...)
+}
+
+// SetMsOlkOrgalias sets the X-MS-OLK-ORGALIAS property for a component
+func SetMsOlkOrgalias(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkOrgalias, value, params...)
+}
+
+// SetMsOlkOriginalend sets the X-MS-OLK-ORIGINALEND property for a component
+func SetMsOlkOriginalend(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkOriginalend, value, params...)
+}
+
+// SetMsOlkOriginalstart sets the X-MS-OLK-ORIGINALSTART property for a component
+func SetMsOlkOriginalstart(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkOriginalstart, value, params...)
+}
+
+// SetMsOlkSender sets the X-MS-OLK-SENDER property for a component
+func SetMsOlkSender(c ical.Component, value string, params ...ical.PropertyParameter) {
+	SetComponentProperty(c, ComponentPropertyMsOlkSender, value, params...)
+}

--- a/extensions/microsoft/microsoft_test.go
+++ b/extensions/microsoft/microsoft_test.go
@@ -7,28 +7,28 @@ import (
 
 func TestCalendarProperties(t *testing.T) {
 	cal := ical.NewCalendar()
-	SetCalname(cal, "Test")
+	cal.SetXWRCalName("Test")
 	SetMicrosoftCalscale(cal, "GREGORIAN")
-	SetPublishedTtl(cal, "PT12H")
+	cal.SetXPublishedTTL("PT12H")
 
 	foundCalname := false
 	foundCalscale := false
 	foundTtl := false
 
 	for _, prop := range cal.CalendarProperties {
-		if prop.IANAToken == PropertyCalname {
+		if prop.IANAToken == string(ical.PropertyXWRCalName) {
 			foundCalname = true
 			if prop.Value != "Test" {
 				t.Errorf("Expected Test, got %s", prop.Value)
 			}
 		}
-		if prop.IANAToken == PropertyMicrosoftCalscale {
+		if prop.IANAToken == string(PropertyMicrosoftCalscale) {
 			foundCalscale = true
 			if prop.Value != "GREGORIAN" {
 				t.Errorf("Expected GREGORIAN, got %s", prop.Value)
 			}
 		}
-		if prop.IANAToken == PropertyPublishedTtl {
+		if prop.IANAToken == string(ical.PropertyXPublishedTTL) {
 			foundTtl = true
 			if prop.Value != "PT12H" {
 				t.Errorf("Expected PT12H, got %s", prop.Value)
@@ -37,13 +37,13 @@ func TestCalendarProperties(t *testing.T) {
 	}
 
 	if !foundCalname {
-		t.Errorf("Property %s not found", PropertyCalname)
+		t.Errorf("Property %s not found", ical.PropertyXWRCalName)
 	}
 	if !foundCalscale {
 		t.Errorf("Property %s not found", PropertyMicrosoftCalscale)
 	}
 	if !foundTtl {
-		t.Errorf("Property %s not found", PropertyPublishedTtl)
+		t.Errorf("Property %s not found", ical.PropertyXPublishedTTL)
 	}
 }
 
@@ -60,25 +60,25 @@ func TestComponentProperties(t *testing.T) {
 	foundIsdraft := false
 
 	for _, prop := range event.Properties {
-		if prop.IANAToken == ComponentPropertyMicrosoftCdoAlldayevent {
+		if prop.IANAToken == string(ComponentPropertyMicrosoftCdoAlldayevent) {
 			foundAllday = true
 			if prop.Value != "TRUE" {
 				t.Errorf("Expected TRUE, got %s", prop.Value)
 			}
 		}
-		if prop.IANAToken == ComponentPropertyMicrosoftCdoBusystatus {
+		if prop.IANAToken == string(ComponentPropertyMicrosoftCdoBusystatus) {
 			foundBusy = true
 			if prop.Value != "OOF" {
 				t.Errorf("Expected OOF, got %s", prop.Value)
 			}
 		}
-		if prop.IANAToken == ComponentPropertyMicrosoftCdoImportance {
+		if prop.IANAToken == string(ComponentPropertyMicrosoftCdoImportance) {
 			foundImp = true
 			if prop.Value != "1" {
 				t.Errorf("Expected 1, got %s", prop.Value)
 			}
 		}
-		if prop.IANAToken == ComponentPropertyMicrosoftIsdraft {
+		if prop.IANAToken == string(ComponentPropertyMicrosoftIsdraft) {
 			foundIsdraft = true
 			if prop.Value != "TRUE" {
 				t.Errorf("Expected TRUE, got %s", prop.Value)

--- a/extensions/microsoft/microsoft_test.go
+++ b/extensions/microsoft/microsoft_test.go
@@ -1,0 +1,101 @@
+package microsoft
+
+import (
+	ical "github.com/arran4/golang-ical"
+	"testing"
+)
+
+func TestCalendarProperties(t *testing.T) {
+	cal := ical.NewCalendar()
+	SetCalname(cal, "Test")
+	SetMicrosoftCalscale(cal, "GREGORIAN")
+	SetPublishedTtl(cal, "PT12H")
+
+	foundCalname := false
+	foundCalscale := false
+	foundTtl := false
+
+	for _, prop := range cal.CalendarProperties {
+		if prop.IANAToken == PropertyCalname {
+			foundCalname = true
+			if prop.Value != "Test" {
+				t.Errorf("Expected Test, got %s", prop.Value)
+			}
+		}
+		if prop.IANAToken == PropertyMicrosoftCalscale {
+			foundCalscale = true
+			if prop.Value != "GREGORIAN" {
+				t.Errorf("Expected GREGORIAN, got %s", prop.Value)
+			}
+		}
+		if prop.IANAToken == PropertyPublishedTtl {
+			foundTtl = true
+			if prop.Value != "PT12H" {
+				t.Errorf("Expected PT12H, got %s", prop.Value)
+			}
+		}
+	}
+
+	if !foundCalname {
+		t.Errorf("Property %s not found", PropertyCalname)
+	}
+	if !foundCalscale {
+		t.Errorf("Property %s not found", PropertyMicrosoftCalscale)
+	}
+	if !foundTtl {
+		t.Errorf("Property %s not found", PropertyPublishedTtl)
+	}
+}
+
+func TestComponentProperties(t *testing.T) {
+	event := ical.NewEvent("1")
+	SetMicrosoftCdoAlldayevent(event, "TRUE")
+	SetMicrosoftCdoBusystatus(event, "OOF")
+	SetMicrosoftCdoImportance(event, "1")
+	SetMicrosoftIsdraft(event, "TRUE")
+
+	foundAllday := false
+	foundBusy := false
+	foundImp := false
+	foundIsdraft := false
+
+	for _, prop := range event.Properties {
+		if prop.IANAToken == ComponentPropertyMicrosoftCdoAlldayevent {
+			foundAllday = true
+			if prop.Value != "TRUE" {
+				t.Errorf("Expected TRUE, got %s", prop.Value)
+			}
+		}
+		if prop.IANAToken == ComponentPropertyMicrosoftCdoBusystatus {
+			foundBusy = true
+			if prop.Value != "OOF" {
+				t.Errorf("Expected OOF, got %s", prop.Value)
+			}
+		}
+		if prop.IANAToken == ComponentPropertyMicrosoftCdoImportance {
+			foundImp = true
+			if prop.Value != "1" {
+				t.Errorf("Expected 1, got %s", prop.Value)
+			}
+		}
+		if prop.IANAToken == ComponentPropertyMicrosoftIsdraft {
+			foundIsdraft = true
+			if prop.Value != "TRUE" {
+				t.Errorf("Expected TRUE, got %s", prop.Value)
+			}
+		}
+	}
+
+	if !foundAllday {
+		t.Errorf("Property %s not found", ComponentPropertyMicrosoftCdoAlldayevent)
+	}
+	if !foundBusy {
+		t.Errorf("Property %s not found", ComponentPropertyMicrosoftCdoBusystatus)
+	}
+	if !foundImp {
+		t.Errorf("Property %s not found", ComponentPropertyMicrosoftCdoImportance)
+	}
+	if !foundIsdraft {
+		t.Errorf("Property %s not found", ComponentPropertyMicrosoftIsdraft)
+	}
+}

--- a/extensions/xapple/xapple.go
+++ b/extensions/xapple/xapple.go
@@ -4,17 +4,21 @@ import (
 	ical "github.com/arran4/golang-ical"
 )
 
-// PropertyCalendarColor is the X-APPLE-CALENDAR-COLOR property
-const PropertyCalendarColor = "X-APPLE-CALENDAR-COLOR"
+const (
+	// PropertyCalendarColor is the X-APPLE-CALENDAR-COLOR property
+	PropertyCalendarColor ical.Property = "X-APPLE-CALENDAR-COLOR"
 
-// PropertyRegion is the X-APPLE-REGION property
-const PropertyRegion = "X-APPLE-REGION"
+	// PropertyRegion is the X-APPLE-REGION property
+	PropertyRegion ical.Property = "X-APPLE-REGION"
+)
 
-// ComponentPropertyStructuredLocation is the X-APPLE-STRUCTURED-LOCATION component property
-const ComponentPropertyStructuredLocation = "X-APPLE-STRUCTURED-LOCATION"
+const (
+	// ComponentPropertyStructuredLocation is the X-APPLE-STRUCTURED-LOCATION component property
+	ComponentPropertyStructuredLocation ical.ComponentProperty = "X-APPLE-STRUCTURED-LOCATION"
 
-// ComponentPropertyTravelDuration is the X-APPLE-TRAVEL-DURATION component property
-const ComponentPropertyTravelDuration = "X-APPLE-TRAVEL-DURATION"
+	// ComponentPropertyTravelDuration is the X-APPLE-TRAVEL-DURATION component property
+	ComponentPropertyTravelDuration ical.ComponentProperty = "X-APPLE-TRAVEL-DURATION"
+)
 
 type propertySetter interface {
 	SetProperty(property ical.ComponentProperty, value string, props ...ical.PropertyParameter)
@@ -68,22 +72,22 @@ func SetComponentProperty(c ical.Component, property string, value string, param
 
 // SetCalendarColor sets the X-APPLE-CALENDAR-COLOR property for the calendar
 func SetCalendarColor(cal *ical.Calendar, color string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyCalendarColor, color, params...)
+	SetProperty(cal, string(PropertyCalendarColor), color, params...)
 }
 
 // SetRegion sets the X-APPLE-REGION property for the calendar
 func SetRegion(cal *ical.Calendar, region string, params ...ical.PropertyParameter) {
-	SetProperty(cal, PropertyRegion, region, params...)
+	SetProperty(cal, string(PropertyRegion), region, params...)
 }
 
 // Component properties
 
 // SetStructuredLocation sets the X-APPLE-STRUCTURED-LOCATION property for a component
 func SetStructuredLocation(c ical.Component, location string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyStructuredLocation, location, params...)
+	SetComponentProperty(c, string(ComponentPropertyStructuredLocation), location, params...)
 }
 
 // SetTravelDuration sets the X-APPLE-TRAVEL-DURATION property for a component
 func SetTravelDuration(c ical.Component, duration string, params ...ical.PropertyParameter) {
-	SetComponentProperty(c, ComponentPropertyTravelDuration, duration, params...)
+	SetComponentProperty(c, string(ComponentPropertyTravelDuration), duration, params...)
 }

--- a/extensions/xapple/xapple_test.go
+++ b/extensions/xapple/xapple_test.go
@@ -1,9 +1,9 @@
 package xapple
 
 import (
+	ical "github.com/arran4/golang-ical"
 	"strings"
 	"testing"
-	ical "github.com/arran4/golang-ical"
 )
 
 func TestAppleProperties(t *testing.T) {


### PR DESCRIPTION
Adds `extensions/microsoft` which provides getter/setter helpers for properties like `X-MICROSOFT-CALSCALE`, `X-MICROSOFT-CDO-ALLDAYEVENT` and others, based on MS-OXCICAL.

---
*PR created automatically by Jules for task [9194524322677490588](https://jules.google.com/task/9194524322677490588) started by @arran4*