### PR TITLE
doc: clarify CRLF requirement for RFC 5545 serialization compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ When to use which constructor:
 
 Use `NewCalendarFor(service)` when you publish ICS from multiple applications/tenants and want each feed to identify its producer via `PRODID` while still using library defaults.
 
+### Important Note on Line Endings (RFC 5545 Compliance)
+
+By default, `.Serialize()` uses Unix-style line endings (`LF`). To strictly comply with the iCalendar specification (**RFC 5545**), which requires Windows-style line endings (`CRLF`) for broad compatibility with email and calendar clients like Outlook and Apple Calendar, pass the explicit formatting option:
+
+```golang
+return cal.Serialize(ics.WithNewLineWindows)
+```
+
 ## Parsing malformed properties (strict/skip/recover)
 
 By default, parsing is strict and returns an error for malformed content lines.

--- a/calendar.go
+++ b/calendar.go
@@ -436,8 +436,13 @@ func NewCalendarFor(service string) *Calendar {
 	return c
 }
 
-// Serialize converts the internal calendar object into its raw text representation.
-// By default, uses Unix-style line endings (LF). To strictly comply with the iCalendar
+// Serialize converts the Calendar and all its nested components (such as events,
+// timezones, and alarms) into a single, fully formatted iCalendar string.
+//
+// It accepts optional configuration arguments (ops) to customize the output layout,
+// such as setting custom line folding lengths or overriding line endings.
+//
+// Note on Line Endings: By default, uses Unix-style line endings (LF). To strictly comply with the iCalendar
 // specification (RFC 5545), which requires Windows-style line endings (CRLF) for broad
 // compatibility with clients like Outlook and Apple Calendar, pass the explicit formatting option:
 //

--- a/calendar.go
+++ b/calendar.go
@@ -436,6 +436,12 @@ func NewCalendarFor(service string) *Calendar {
 	return c
 }
 
+// Serialize converts the internal calendar object into its raw text representation.
+// By default, uses Unix-style line endings (LF). To strictly comply with the iCalendar
+// specification (RFC 5545), which requires Windows-style line endings (CRLF) for broad
+// compatibility with clients like Outlook and Apple Calendar, pass the explicit formatting option:
+//
+//	cal.Serialize(ics.WithNewLineWindows)
 func (cal *Calendar) Serialize(ops ...any) string {
 	b := &strings.Builder{}
 	// We are intentionally ignoring the return value. _ used to communicate this to lint.
@@ -652,8 +658,6 @@ func (cal *Calendar) addComponent(c Component) {
 	}
 	cal.Components = append(cal.Components, c)
 }
-
-
 
 func (cal *Calendar) setProperty(property Property, value string, params ...PropertyParameter) {
 	for i := range cal.CalendarProperties {


### PR DESCRIPTION
Closes #116. Adds documentation notes to the README and the Serialize GoDoc comment clarifying that ics.WithNewLineWindows is required for strict RFC line-ending compliance.