### PR TITLE
Escape control characters in TEXT values (RFC 5545 §3.3.11)

### DIFF
--- a/property.go
+++ b/property.go
@@ -525,12 +525,33 @@ func parsePropertyValue(r *BaseProperty, contentLine string, p int) *BasePropert
 	return r
 }
 
-var textEscaper = strings.NewReplacer(
-	`\`, `\\`,
-	"\n", `\n`,
-	`;`, `\;`,
-	`,`, `\,`,
-)
+// textEscaper escapes the specials RFC 5545 §3.3.11 requires in a TEXT value
+// and normalises line breaks to the \n escape: CR, CRLF and LF all collapse to
+// \n (FromText maps \n back to LF, so CR/CRLF round-trip as LF). The remaining
+// control characters have no escaped form (CONTROL = %x00-08 / %x0A-1F / %x7F,
+// i.e. everything but HTAB) and are dropped so serialization can never emit an
+// invalid content line.
+var textEscaper = newTextEscaper()
+
+func newTextEscaper() *strings.Replacer {
+	// "\r\n" must precede "\r" so a CRLF collapses to a single \n.
+	pairs := []string{
+		`\`, `\\`,
+		"\r\n", `\n`,
+		"\r", `\n`,
+		"\n", `\n`,
+		`;`, `\;`,
+		`,`, `\,`,
+	}
+	for c := 0x00; c <= 0x1F; c++ {
+		if c == '\t' || c == '\n' || c == '\r' {
+			continue
+		}
+		pairs = append(pairs, string(rune(c)), "")
+	}
+	pairs = append(pairs, "\x7f", "")
+	return strings.NewReplacer(pairs...)
+}
 
 func ToText(s string) string {
 	// Some special characters for iCalendar format should be escaped while

--- a/property_test.go
+++ b/property_test.go
@@ -1,6 +1,7 @@
 package ics
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -251,5 +252,69 @@ func TestFixValueStrings(t *testing.T) {
 				t.Errorf("got %q, want %q", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestToText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// unchanged escaping of the existing specials
+		{"backslash", `a\b`, `a\\b`},
+		{"semicolon", "a;b", `a\;b`},
+		{"comma", "a,b", `a\,b`},
+		{"lf", "a\nb", `a\nb`},
+		// a literal backslash-n must not be double-escaped, only the backslash
+		{"literal escape stays single", `a\nb`, `a\\nb`},
+		// line-break normalisation: CR, CRLF and LF all become a single \n
+		{"cr", "a\rb", `a\nb`},
+		{"crlf", "line1\r\nline2", `line1\nline2`},
+		{"double crlf", "a\r\n\r\nb", `a\n\nb`},
+		{"lf then cr", "a\n\rb", `a\n\nb`},
+		// HTAB is the one control RFC 5545 permits in TEXT
+		{"htab kept", "a\tb", "a\tb"},
+		// every other control character has no escape and is dropped
+		{"nul", "a\x00b", "ab"},
+		{"bel", "a\x07b", "ab"},
+		{"vertical tab", "a\x0bb", "ab"},
+		{"form feed", "a\x0cb", "ab"},
+		{"escape", "a\x1bb", "ab"},
+		{"del", "a\x7fb", "ab"},
+		{"mixed", "x,y;z\\w\ne\rf", `x\,y\;z\\w\ne\nf`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ToText(tt.input))
+		})
+	}
+}
+
+// TestSerializeNoRawControlCharacters checks that no TEXT value can put a
+// disallowed raw control byte into a serialized content line, across the whole
+// control range 0x00-0x1F and 0x7F (RFC 5545 §3.3.11 CONTROL, HTAB excepted).
+func TestSerializeNoRawControlCharacters(t *testing.T) {
+	for b := 0; b <= 0x7F; b++ {
+		if b > 0x1F && b != 0x7F {
+			continue // not a control character
+		}
+		cal := NewCalendar()
+		event := cal.AddEvent("uid")
+		event.SetProperty(ComponentPropertySummary, "A"+string(rune(b))+"B")
+		serialized := cal.Serialize(WithNewLineWindows)
+		// with the CRLF delimiter stripped, nothing left in a content line may
+		// be a disallowed control byte
+		for _, line := range strings.Split(serialized, "\r\n") {
+			for i := 0; i < len(line); i++ {
+				c := line[i]
+				if c == '\t' {
+					continue // HTAB is allowed
+				}
+				if c < 0x20 || c == 0x7F {
+					t.Fatalf("input control 0x%02x produced raw control 0x%02x in content line %q", b, c, line)
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
`ToText`/`textEscaper` escapes `\`, `;`, `,` and LF, but passes every other control character through unchanged. RFC 5545 §3.3.11 builds a `TEXT` value from `TSAFE-CHAR / ":" / DQUOTE / ESCAPED-CHAR` and excludes `CONTROL = %x00-08 / %x0A-1F / %x7F` (every control byte except HTAB). So a value containing a control byte currently serializes to an invalid content line. This affects every TEXT-typed property (SUMMARY, DESCRIPTION, LOCATION, COMMENT, UID, CATEGORIES, TZID, X-* defaulting to TEXT, ...), since they all go through `ToText`.

Repro:

```go
cal := ics.NewCalendar()
cal.AddEvent("uid").SetProperty(ics.ComponentPropertySummary, "line1\r\nline2")
fmt.Print(cal.Serialize(ics.WithNewLineWindows))
// before: SUMMARY:line1<raw 0x0D>\nline2   (a raw CR inside the content line)
// after:  SUMMARY:line1\nline2
```

A bare NUL/BEL/VT/FF/ESC/DEL leaks the same way. Some readers (e.g. python `icalendar`) parse the line and keep the raw CR, so the invalid byte propagates silently rather than being rejected.

Fix:

- CR, CRLF and a lone LF all normalise to the `\n` escape. The `\r\n` rule is ordered before the lone-`\r` rule so a CRLF collapses to a single `\n`. `FromText` already maps `\n` back to LF, so CR/CRLF round-trip as LF.
- The remaining controls (`%x00-08`, `%x0B-1F`, `%x7F`) have no escaped form in RFC 5545, so they are dropped; HTAB is kept as it is the one control the grammar allows. Stripping keeps `Serialize` infallible. If you would rather reject such input with an error instead of stripping it, I am happy to change it — that is the only open design choice here.

The existing `\` `;` `,` LF handling is unchanged, and because `strings.Replacer` is single-pass there is no double-escaping (`a\b` -> `a\\b`, not `a\\\\b`).

Scope is only the TEXT-value escaper. The parameter-value escapers (`escapeValueString`/`quotedValueString`) and the UTF-8 line folder (#7) are untouched.

`TestToText` covers the escaping/normalisation/stripping cases plus the no-double-escape invariant; `TestSerializeNoRawControlCharacters` asserts no disallowed raw control survives serialization across the whole `0x00-0x1F` / `0x7F` range.
