### PR TITLE
Drop control characters from parameter values (RFC 5545 §3.1)

### DIFF
--- a/property.go
+++ b/property.go
@@ -249,27 +249,21 @@ func serializeTZIDValue(serialConfig *SerializationConfiguration, key, value str
 }
 
 // RFC 5545 3.1 allows no CONTROL in a param-value, and no escape for one.
-var paramValueControlStripper = newParamValueControlStripper()
-
-func newParamValueControlStripper() *strings.Replacer {
-	pairs := make([]string, 0, 66)
-	for c := 0x00; c <= 0x1F; c++ {
-		if c == '\t' {
-			continue // HTAB is WSP, the one control SAFE-CHAR permits
-		}
-		pairs = append(pairs, string(rune(c)), "")
-	}
-	return strings.NewReplacer(append(pairs, "\x7f", "")...)
+// HTAB is WSP, the one control SAFE-CHAR and QSAFE-CHAR permit.
+func isParamValueControl(r rune) bool {
+	return (r < 0x20 || r == 0x7f) && r != '\t'
 }
 
 func escapeValueString(v string) string {
-	v = paramValueControlStripper.Replace(v)
 	changed := 0
 	result := ""
 	for i, r := range v {
-		switch r {
-		case ',', '"', ';', ':', '\\', '\'':
+		switch {
+		case r == ',', r == '"', r == ';', r == ':', r == '\\', r == '\'':
 			result = result + v[changed:i] + "\\" + string(r)
+			changed = i + 1
+		case isParamValueControl(r):
+			result = result + v[changed:i]
 			changed = i + 1
 		}
 	}
@@ -280,13 +274,15 @@ func escapeValueString(v string) string {
 }
 
 func quotedValueString(v string) string {
-	v = paramValueControlStripper.Replace(v)
 	changed := 0
 	result := ""
 	for i, r := range v {
-		switch r {
-		case '"', '\\':
+		switch {
+		case r == '"', r == '\\':
 			result = result + v[changed:i] + "\\" + string(r)
+			changed = i + 1
+		case isParamValueControl(r):
+			result = result + v[changed:i]
 			changed = i + 1
 		}
 	}

--- a/property.go
+++ b/property.go
@@ -248,7 +248,22 @@ func serializeTZIDValue(serialConfig *SerializationConfiguration, key, value str
 	return value
 }
 
+// RFC 5545 3.1 allows no CONTROL in a param-value, and no escape for one.
+var paramValueControlStripper = newParamValueControlStripper()
+
+func newParamValueControlStripper() *strings.Replacer {
+	pairs := make([]string, 0, 66)
+	for c := 0x00; c <= 0x1F; c++ {
+		if c == '\t' {
+			continue // HTAB is WSP, the one control SAFE-CHAR permits
+		}
+		pairs = append(pairs, string(rune(c)), "")
+	}
+	return strings.NewReplacer(append(pairs, "\x7f", "")...)
+}
+
 func escapeValueString(v string) string {
+	v = paramValueControlStripper.Replace(v)
 	changed := 0
 	result := ""
 	for i, r := range v {
@@ -265,6 +280,7 @@ func escapeValueString(v string) string {
 }
 
 func quotedValueString(v string) string {
+	v = paramValueControlStripper.Replace(v)
 	changed := 0
 	result := ""
 	for i, r := range v {

--- a/property_test.go
+++ b/property_test.go
@@ -1,6 +1,8 @@
 package ics
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -250,6 +252,127 @@ func TestFixValueStrings(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("got %q, want %q", result, tt.expected)
 			}
+		})
+	}
+}
+
+func TestParamValueEscapersDropControlCharacters(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		unquoted string
+		quoted   string
+	}{
+		{"htab is WSP and stays", "a\tb", "a\tb", "\"a\tb\""},
+		{"nul", "a\x00b", "ab", `"ab"`},
+		{"bel", "a\ab", "ab", `"ab"`},
+		{"lf", "a\nb", "ab", `"ab"`},
+		{"cr", "a\rb", "ab", `"ab"`},
+		{"crlf", "a\r\nb", "ab", `"ab"`},
+		{"vertical tab", "a\vb", "ab", `"ab"`},
+		{"form feed", "a\fb", "ab", `"ab"`},
+		{"escape", "a\x1bb", "ab", `"ab"`},
+		{"del", "a\x7fb", "ab", `"ab"`},
+		{"non-ascii is not a control", "a\u0080b", "a\u0080b", "\"a\u0080b\""},
+		{"specials are still escaped", `a,b;c:d"e\f`, `a\,b\;c\:d\"e\\f`, `"a,b;c:d\"e\\f"`},
+		{"control between specials", "a\x00,b", `a\,b`, `"a,b"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.unquoted, escapeValueString(tt.input))
+			assert.Equal(t, tt.quoted, quotedValueString(tt.input))
+		})
+	}
+}
+
+func serializeParamValue(t *testing.T, key, value string) string {
+	t.Helper()
+	cal := NewCalendar()
+	event := cal.AddEvent("uid")
+	event.SetProperty(ComponentProperty("X-TEST"), "v", &KeyValues{Key: key, Value: []string{value}})
+	return cal.Serialize(WithNewLineWindows)
+}
+
+func parsedParamValue(t *testing.T, serialized, key string) (string, bool) {
+	t.Helper()
+	cal, err := ParseCalendar(strings.NewReader(serialized))
+	if !assert.NoError(t, err, "serialized output must parse back: %q", serialized) {
+		return "", false
+	}
+	for _, component := range cal.Components {
+		for _, property := range component.UnknownPropertiesIANAProperties() {
+			if property.IANAToken != "X-TEST" {
+				continue
+			}
+			if values, ok := property.ICalParameters[key]; ok && len(values) > 0 {
+				return values[0], true
+			}
+		}
+	}
+	return "", false
+}
+
+func assertNoRawControlCharacter(t *testing.T, serialized string) {
+	t.Helper()
+	for _, line := range strings.Split(serialized, string(WithNewLineWindows)) {
+		for i := 0; i < len(line); i++ {
+			if c := line[i]; (c < 0x20 || c == 0x7F) && c != '\t' {
+				t.Fatalf("raw control 0x%02x in content line %q", c, line)
+			}
+		}
+	}
+}
+
+// A param-value carries no escape mechanism, so serialization has to drop every
+// CONTROL character rather than emit one parsePropertyParamValue rejects.
+func TestSerializeParamValueNoRawControlCharacters(t *testing.T) {
+	// CN is written as paramtext, ALTREP as a quoted-string.
+	for _, key := range []string{"CN", "ALTREP"} {
+		for b := 0x00; b <= 0x7F; b++ {
+			if b > 0x1F && b != 0x7F {
+				continue
+			}
+			t.Run(fmt.Sprintf("%s/0x%02x", key, b), func(t *testing.T) {
+				serialized := serializeParamValue(t, key, "a"+string(rune(b))+"b")
+				assertNoRawControlCharacter(t, serialized)
+
+				want := "ab"
+				if b == '\t' {
+					want = "a\tb"
+				}
+				got, ok := parsedParamValue(t, serialized, key)
+				assert.True(t, ok, "%s must survive the round trip, got %q", key, serialized)
+				assert.Equal(t, want, got)
+			})
+		}
+	}
+}
+
+// The strip must leave everything SAFE-CHAR and QSAFE-CHAR permit alone.
+func TestSerializeParamValuePrintableUnchanged(t *testing.T) {
+	for _, key := range []string{"CN", "ALTREP"} {
+		for b := 0x20; b <= 0x7E; b++ {
+			t.Run(fmt.Sprintf("%s/0x%02x", key, b), func(t *testing.T) {
+				want := "a" + string(rune(b)) + "b"
+				got, ok := parsedParamValue(t, serializeParamValue(t, key, want), key)
+				assert.True(t, ok, "%s must survive the round trip", key)
+				assert.Equal(t, want, got)
+			})
+		}
+	}
+}
+
+func TestSerializeParamValueControlAcrossFold(t *testing.T) {
+	for _, key := range []string{"CN", "ALTREP"} {
+		t.Run(key, func(t *testing.T) {
+			want := strings.Repeat("x", 70) + strings.Repeat("y", 20)
+			serialized := serializeParamValue(t, key, strings.Repeat("x", 70)+"\v"+strings.Repeat("y", 20))
+			assert.Contains(t, serialized, string(WithNewLineWindows)+" ", "value must be long enough to fold")
+			assertNoRawControlCharacter(t, serialized)
+
+			got, ok := parsedParamValue(t, serialized, key)
+			assert.True(t, ok, "%s must survive the round trip", key)
+			assert.Equal(t, want, got)
 		})
 	}
 }


### PR DESCRIPTION
`ev.SetProperty(ics.ComponentProperty("X-TEST"), "v", &ics.KeyValues{Key: "CN", Value: []string{"a\vb"}})` serialises to `X-TEST;CN=a<0x0B>b:v`, and handing that output straight back to `ParseCalendar` fails with `parse error: unexpected char ascii:11 in property param value CN in X-TEST` — the whole calendar is lost, not just that one property. `escapeValueString` and `quotedValueString` pass control bytes through untouched while `parsePropertyParamValue` rejects `%x00-08` and `%x0A-1F`, so the serialiser emits 32 bytes per parameter kind that its own parser refuses; RFC 5545 §3.1 settles which side is wrong, since `param-value = paramtext / quoted-string` and both SAFE-CHAR and QSAFE-CHAR exclude `CONTROL = %x00-08 / %x0A-1F / %x7F`, HTAB excepted.

This drops them in both escapers, the same answer #150 gives for TEXT values; DEL is included because it is CONTROL too, though I deliberately left the parser's tolerance of it alone rather than make the reader stricter than it is today. LF is the one byte a standard could preserve instead — RFC 6868 defines `^n`, and python-icalendar 7.2.2 and ical.js 2.2.1 both emit it — but golang-ical has no caret encoding on either side, so writing `^n` now would just come back as literal text; happy to add RFC 6868 properly as a follow-up if you want it.

The tests sweep `0x00-0x1F` and `0x7F` through an unquoted parameter (CN) and a quoted one (ALTREP), 64 of those 66 cases failing on master, plus a folded value and a 190-case sweep of `0x20-0x7E` that passes before *and* after so nothing legal got dropped; `go test -race ./...` goes from 165 to 440 passing subtests with no failures, `go vet` is clean and `gofmt -l .` is unchanged. Unrelated to this path but found while auditing it: non-TEXT property values get no escaping at all, so `SetProperty(PropertyUrl, "http://x/\r\nX-INJECTED:evil")` writes two content lines and the injected property survives a full round trip — a separate fix from this one and from #150, say the word if you would like it.
