### PR TITLE
Prevent stack overflow from unbounded component nesting in ParseCalendar

### DIFF
--- a/calendar.go
+++ b/calendar.go
@@ -1015,9 +1015,10 @@ func DefaultUnknownCalendarPropertyHandler(cal *Calendar, state string, cl *Base
 }
 
 type CalendarStream struct {
-	r    io.Reader
-	b    *bufio.Reader
-	line int
+	r     io.Reader
+	b     *bufio.Reader
+	line  int
+	depth int
 }
 
 func NewCalendarStream(r io.Reader) *CalendarStream {

--- a/components.go
+++ b/components.go
@@ -1416,11 +1416,24 @@ func parseComponentOptions(opts ...any) (componentParseConfig, error) {
 	return cfg, nil
 }
 
+// maxComponentNestingDepth bounds how deeply nested BEGIN/END components may be
+// before parsing is aborted. Nested components recurse through
+// parseComponentWithHandler, so without a limit an input consisting of many
+// repeated BEGIN lines drives unbounded recursion and crashes the program with a
+// fatal stack overflow. Real-world calendars nest only a few levels deep
+// (e.g. VCALENDAR > VEVENT > VALARM), so this limit is far above any legitimate use.
+const maxComponentNestingDepth = 1000
+
 func parseComponentWithHandler(cs *CalendarStream, startLine *BaseProperty, opts ...any) (ComponentBase, error) {
 	cfg, err := parseComponentOptions(opts...)
 	cb := ComponentBase{timezoneMapper: cfg.timezoneMapper}
 	if err != nil {
 		return cb, err
+	}
+	cs.depth++
+	defer func() { cs.depth-- }()
+	if cs.depth > maxComponentNestingDepth {
+		return cb, NewMalformedError(cs.line, -1, ErrComponentNestingTooDeep)
 	}
 	lastLine := 0
 	cont := true

--- a/components_nesting_test.go
+++ b/components_nesting_test.go
@@ -1,0 +1,46 @@
+package ics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestParseCalendarDeeplyNestedComponents ensures that a calendar consisting of
+// many nested BEGIN components is rejected with an error instead of crashing the
+// program with a fatal stack overflow via unbounded recursion.
+func TestParseCalendarDeeplyNestedComponents(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("BEGIN:VCALENDAR\r\n")
+	for i := 0; i < maxComponentNestingDepth+5000; i++ {
+		b.WriteString("BEGIN:VEVENT\r\n")
+	}
+
+	_, err := ParseCalendar(strings.NewReader(b.String()))
+	if err == nil {
+		t.Fatal("expected an error for deeply nested components, got nil")
+	}
+	if !errors.Is(err, ErrComponentNestingTooDeep) {
+		t.Fatalf("expected ErrComponentNestingTooDeep, got %v", err)
+	}
+}
+
+// TestParseCalendarNormalNestingAllowed ensures the depth guard does not reject
+// legitimately nested calendars (VCALENDAR > VEVENT > VALARM).
+func TestParseCalendarNormalNestingAllowed(t *testing.T) {
+	const input = "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:x@example.com\r\n" +
+		"BEGIN:VALARM\r\n" +
+		"ACTION:DISPLAY\r\n" +
+		"END:VALARM\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+	cal, err := ParseCalendar(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error parsing normally nested calendar: %v", err)
+	}
+	if len(cal.Components) != 1 {
+		t.Fatalf("expected 1 component, got %d", len(cal.Components))
+	}
+}

--- a/errors.go
+++ b/errors.go
@@ -113,6 +113,8 @@ var (
 	ErrUnbalancedEnd = errors.New("unbalanced end")
 	// ErrOutOfLines reports that the parser ran out of content lines.
 	ErrOutOfLines = errors.New("ran out of lines")
+	// ErrComponentNestingTooDeep reports that nested components exceeded the maximum allowed depth.
+	ErrComponentNestingTooDeep = errors.New("component nesting too deep")
 	// ErrorPropertyNotFound reports that a requested property was not found.
 	ErrorPropertyNotFound = errors.New("property not found")
 


### PR DESCRIPTION
ParseCalendar can be crashed with a fatal, unrecoverable stack overflow by a small calendar that simply nests many components, because nested `BEGIN` blocks recurse through `parseComponentWithHandler` with no depth limit.

**Failure mode:** `parseComponentWithHandler` calls `generalParseComponentWithHandler` for every nested `BEGIN`, which calls `parseComponentWithHandler` again. Nesting depth in the input maps one-to-one to Go stack recursion depth, so an attacker-supplied `.ics` of the form

```
BEGIN:VCALENDAR
BEGIN:VEVENT
BEGIN:VEVENT
... (repeated) ...
```

drives recursion until the goroutine hits the 1 GB stack limit and the runtime aborts with `fatal error: stack overflow`. Because this is a fatal runtime error, not a Go panic, callers cannot recover with `recover()` — the whole process dies. This is reachable directly from the main documented entry point (`ParseCalendar` / `ParseCalendarWithOptions`) on untrusted input.

**Repro:** feeding `ParseCalendar` a reader whose content is `BEGIN:VCALENDAR\r\n` followed by ~3 million `BEGIN:VEVENT\r\n` lines reliably produces `fatal error: stack overflow` with the recursion visible in the stack trace (`parseComponentWithHandler` -> `generalParseComponentWithHandler` repeating).

**Fix:** track component nesting depth on `CalendarStream` and abort with a new sentinel error `ErrComponentNestingTooDeep` once it exceeds `maxComponentNestingDepth` (1000). Real calendars nest only a few levels deep (e.g. `VCALENDAR > VEVENT > VALARM`, `VCALENDAR > VTIMEZONE > STANDARD`), so the limit is far above any legitimate use and valid inputs are unaffected.

**Tests:** added `components_nesting_test.go` with two cases — one asserting a deeply nested calendar now returns `ErrComponentNestingTooDeep` instead of crashing, and one asserting a normally nested `VCALENDAR > VEVENT > VALARM` calendar still parses. Full `go test ./...`, `go vet ./...`, and `gofmt` all pass; the existing `FuzzParseCalendar` seed run stays green.