### PR TITLE
Convert UNTIL to UTC before formatting it

### DIFF
--- a/recurrence.go
+++ b/recurrence.go
@@ -202,7 +202,7 @@ func (r *RecurrenceRule) String() string {
 		if r.UntilDateOnly {
 			parts = append(parts, "UNTIL="+r.Until.Format(icalDateFormatLocal))
 		} else {
-			parts = append(parts, "UNTIL="+r.Until.Format(icalTimestampFormatUtc))
+			parts = append(parts, "UNTIL="+r.Until.UTC().Format(icalTimestampFormatUtc))
 		}
 	}
 	if r.Count != 0 {

--- a/recurrence_test.go
+++ b/recurrence_test.go
@@ -247,6 +247,21 @@ func TestRecurrenceRuleString(t *testing.T) {
 	}
 }
 
+func TestRecurrenceRuleStringUntilIsUTC(t *testing.T) {
+	// UNTIL is written with a literal "Z", so a non-UTC Until has to be
+	// converted rather than formatted in place (RFC 5545 3.3.10).
+	jst := time.FixedZone("JST", 9*60*60)
+	until := time.Date(2026, 3, 1, 10, 0, 0, 0, jst)
+
+	r := &RecurrenceRule{Freq: FrequencyDaily, Until: until}
+	assert.Equal(t, "FREQ=DAILY;UNTIL=20260301T010000Z", r.String())
+
+	back, err := ParseRecurrenceRule(r.String())
+	require.NoError(t, err)
+	assert.True(t, back.Until.Equal(until),
+		"round trip moved the instant: got %s, want %s", back.Until.UTC(), until.UTC())
+}
+
 func TestGetRRules(t *testing.T) {
 	event := NewEvent("test-rrule")
 	event.AddRrule("FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU")


### PR DESCRIPTION
## Description

`RecurrenceRule.String()` serializes a non-UTC `Until` to the wrong instant.

`icalTimestampFormatUtc` is `"20060102T150405Z"`. Go only recognises `Z0700` and `Z07:00` as zone specifiers, so the trailing `Z` here is a literal: `Format` writes the time's wall-clock digits and then staples on a `Z` that asserts UTC.

```go
jst := time.FixedZone("JST", 9*3600)
until := time.Date(2026, 3, 1, 10, 0, 0, 0, jst)   // 2026-03-01T01:00:00Z

r := &RecurrenceRule{Freq: FrequencyDaily, Until: until}
r.String()   // FREQ=DAILY;UNTIL=20260301T100000Z
```

Nothing errors and the output is a well-formed RRULE — it just ends the recurrence nine hours late. Parsing it back returns an instant shifted by the zone offset:

```
Until (in JST)   = 2026-03-01T10:00:00+09:00
Until (true UTC) = 2026-03-01T01:00:00Z
String()         = FREQ=DAILY;UNTIL=20260301T100000Z
round trip moved the instant by 9h0m0s
```

RFC 5545 §3.3.10 requires the UNTIL value to be UTC when it is a DATE-TIME.

The other ten uses of this format constant already convert first — `components.go:237,241,245,253,265,698,702,796,805` and `calendar.go:619` all call `t.UTC().Format(icalTimestampFormatUtc)`. `recurrence.go:205` was the one that did not, so this restores the house pattern rather than introducing one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Must haves

- [x] I have commented in hard-to-understand areas and anywhere the function not immediately apparent
- [x] I have made corresponding changes to the comments (if any)
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective or that my feature works
- [x] I have added tests that protects the code from degradation in the future

## Why the existing tests do not catch it

`TestRecurrenceRuleString` round-trips strings, and every UNTIL in it (`UNTIL=20251231T235959Z`, `UNTIL=20251231T000000Z`) has already been parsed into UTC by `parseRecurrenceTime`, so the serializer is location-neutral in all of them. No existing case constructs a `RecurrenceRule` with a non-UTC `Until` in Go, which is the only way to reach this. The added test does exactly that and also asserts the round trip preserves the instant.

## Verification

`go test ./...` green before and after, including the four extension packages. Reverting only `recurrence.go` and keeping the test fails on `expected: "FREQ=DAILY;UNTIL=20260301T010000Z"`, so the new test exercises this bug rather than the serializer in general. `go vet ./...` clean, `gofmt -l` clean on both changed files.

---

*Disclosure: this patch was prepared with AI assistance. The reproduction, the red/green check and the suite runs above were executed against this branch; happy to adjust anything on request.*
